### PR TITLE
Add Sidon set OEIS links to the main Sidon set problem.

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -324,7 +324,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A143824","A227590","A003022"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
The main Sidon set problem is [#30](https://www.erdosproblems.com/30).  The term $h(N)$ there corresponds to OEIS [A143824](https://oeis.org/A143824), which is the first link added.  I also added its inverse, as well as the *main* Sidon set sequence in OEIS, which subtracts 1 from that.

I did *not* add these links to other Sidon set-related problems, eg [#43](https://www.erdosproblems.com/43) because I do not know whether we want all relevant links or just the ones closest to the problem.  For example, for 43, I would consider the main sequence to be the maximum size of $\binom{\lvert A\rvert}{2} + \binom{\lvert B\rvert}{2}$ (with or without $\lvert A\rvert=\lvert B\rvert$), not $f(N)$.