### PR TITLE
add workflow to update formal-conjectures status

### DIFF
--- a/.github/workflows/update-formal-conjectures.yml
+++ b/.github/workflows/update-formal-conjectures.yml
@@ -1,0 +1,37 @@
+name: Update from Formal Conjectures
+
+on:
+  repository_dispatch:
+    types: [formal-conjecture-updated] 
+  workflow_dispatch: 
+
+jobs:
+  update-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run update script
+        run: python3 scripts/update_formalization_status.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add data/problems.yaml
+          
+          if git diff --staged --quiet; then
+            echo "🧘 No changes to commit."
+          else
+            git commit -m "🤖 Auto-update formalization status from formal-conjectures"
+            git push
+          fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==6.0.2
 jsonschema==4.23.0
+ruamel.yaml==0.18.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0.2
 jsonschema==4.23.0
+requests==2.32.5
 ruamel.yaml==0.18.15


### PR DESCRIPTION
Can be triggered manually or by sending a `repository_dispatch` event from the formal-conjectures repo when new files are added there.