### PR TITLE
Update OEIS for problem 144 (A005279)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -1588,10 +1588,10 @@
   status:
     state: "solved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A005279"]
   formalized:
     state: "no"
-    last_update: "2025-08-31"
+    last_update: "2025-09-01"
   tags: ["number theory", "divisors"]
 
 - number: "145"


### PR DESCRIPTION
Problem 144: [link](https://www.erdosproblems.com/144)

I computed first few numbers with the following sage code and searched on OEIS. [A005279](https://oeis.org/A005279)

```sage
def erdos144(n):
    ds = list(divisors(n))
    for i in range(len(ds) - 1):
        if ds[i+1] < 2 * ds[i]:
            return True, (ds[i], ds[i+1])
    return False, None


for i in range(1, 100):
    check, pair = erdos144(i)
    if check:
        print(i, pair)
```

(outputs)

```
6 (2, 3)
12 (2, 3)
15 (3, 5)
18 (2, 3)
20 (4, 5)
24 (2, 3)
28 (4, 7)
30 (2, 3)
35 (5, 7)
36 (2, 3)
40 (4, 5)
42 (2, 3)
45 (3, 5)
48 (2, 3)
54 (2, 3)
56 (4, 7)
60 (2, 3)
63 (7, 9)
66 (2, 3)
70 (5, 7)
72 (2, 3)
75 (3, 5)
77 (7, 11)
78 (2, 3)
80 (4, 5)
84 (2, 3)
88 (8, 11)
90 (2, 3)
91 (7, 13)
96 (2, 3)
99 (9, 11)
```

Also, if I read the OEIS page correctly, it seems that the Maier and Tenenbaum's paper is not linked there.