### PR TITLE
add permissions to workflow

### DIFF
--- a/.github/workflows/update-formal-conjectures.yml
+++ b/.github/workflows/update-formal-conjectures.yml
@@ -5,6 +5,9 @@ on:
     types: [formal-conjecture-updated] 
   workflow_dispatch: 
 
+permissions:
+  contents: write
+
 jobs:
   update-files:
     runs-on: ubuntu-latest
@@ -25,8 +28,8 @@ jobs:
 
       - name: Commit and push changes
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/problems.yaml
           
           if git diff --staged --quiet; then


### PR DESCRIPTION
drive-by:
use the same commit name and email as in the other workflow