### PR TITLE
Add related sequence for p968.

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10685,7 +10685,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A233866"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
This sequence is related to the problem, though it's actually a subsequence (restricted to Ramanujan primes) of the relevant sequence: https://oeis.org/A233866

The full sequence of primes such that (n+1)p_n > n * p_{n+1} isn't an OEIS sequence yet. (The sequence relevant to the problem would the complement.)