### PR TITLE
add # of problems with possible OEIS but no existing OEIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ For further discussion of this project, see [this blog post](https://terrytao.wo
 <!-- TABLE:START -->
 There are 992 problems in total, of which
 - 94 are attached to a monetary prize.
-- 233 have been proved (with 2 of these proofs formalized in Lean).
-- 80 have been disproved (with 1 of these disproofs formalized in Lean).
+- 233 have been proved.
+  - 2 of these proofs have been formalized in Lean.
+- 80 have been disproved.
+  - 1 of these disproofs have been formalized in Lean.
 - 38 have been otherwise solved.
 - 5 are open, but have been reduced to a finite computation. (decidable)
 - 35 are open, but can be disproven by a finite computation if false. (falsifiable)
@@ -23,6 +25,7 @@ There are 992 problems in total, of which
 - 157 have their statements formalized in Lean in the [Formal Conjectures Repository](https://github.com/google-deepmind/formal-conjectures).
 - 94 are known to be related to at least one [OEIS](https://oeis.org/) sequence.
 - 364 are potentially related to an [OEIS](https://oeis.org/) sequence not already listed.
+  - 358 of these are not currently linked to any existing OEIS sequence.
 
 
 | # | Prize | Status | Formalized | OEIS | Tags | Comments |

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -48,6 +48,18 @@ def count_rows_with_oeis_id(rows):
         if any(re.fullmatch(r"A\d{6}", s) for s in r.get("oeis", []))
     )
 
+def count_possible_and_id(rows):
+    """
+    Count rows whose 'oeis' list contains BOTH
+    - at least one entry with substring 'possible'
+    - at least one entry matching A\\d{6}
+    """
+    return sum(
+        1 for r in rows
+        if any("possible" in entry for entry in r.get("oeis", []))
+        and any(re.fullmatch(r"A\d{6}", s) for s in r.get("oeis", []))
+    )
+
 def count_formalized_yes(rows):
     """
     Count how many rows have formalized.state == "yes".
@@ -153,16 +165,19 @@ def build_table(rows):
     lines = []
     lines.append(f"There are {len(rows)} problems in total, of which")
     lines.append(f"- {count_prize(rows)} are attached to a monetary prize.")
-    lines.append(f"- {count_proved(rows)+count_proved_lean(rows)} have been proved (with {count_proved_lean(rows)} of these proofs formalized in Lean).")
-    lines.append(f"- {count_disproved(rows)+count_disproved_lean(rows) } have been disproved (with {count_disproved_lean(rows)} of these disproofs formalized in Lean).")
+    lines.append(f"- {count_proved(rows)+count_proved_lean(rows)} have been proved.")
+    lines.append(f"  - {count_proved_lean(rows)} of these proofs have been formalized in [Lean](https://lean-lang.org/).")
+    lines.append(f"- {count_disproved(rows)+count_disproved_lean(rows) } have been disproved.")
+    lines.append(f"  - {count_disproved_lean(rows)} of these disproofs have been formalized in [Lean](https://lean-lang.org/).")
     lines.append(f"- {count_solved(rows)} have been otherwise solved.")
     lines.append(f"- {count_decidable(rows)} are open, but have been reduced to a finite computation. (decidable)")
     lines.append(f"- {count_falsifiable(rows)} are open, but can be disproven by a finite computation if false. (falsifiable)")
     lines.append(f"- {count_verifiable(rows)} are open, but can be proven by a finite computation if true. (verifiable)")
     lines.append(f"- {count_open(rows)} are completely open.")
-    lines.append(f"- {count_formalized_yes(rows)} have their statements formalized in Lean in the [Formal Conjectures Repository](https://github.com/google-deepmind/formal-conjectures).")
+    lines.append(f"- {count_formalized_yes(rows)} have their statements formalized in [Lean](https://lean-lang.org/) in the [Formal Conjectures Repository](https://github.com/google-deepmind/formal-conjectures).")
     lines.append(f"- {count_rows_with_oeis_id(rows)} are known to be related to at least one [OEIS](https://oeis.org/) sequence.")
     lines.append(f"- {count_possible_oeis(rows)} are potentially related to an [OEIS](https://oeis.org/) sequence not already listed.")
+    lines.append(f"  - {count_possible_oeis(rows)-count_possible_and_id(rows)} of these problems are not currently linked to any existing [OEIS](https://oeis.org/) sequence.")
     lines.append("\n")
     lines.append(header)
     for r in rows:


### PR DESCRIPTION
Modify the stats at the start of the autogenerated table to list the number of problems that could potentially be linked to an OEIS sequence, but are currently not linked to any of them.  This is a target number to make as small as possible!