### PR TITLE
Erdos 416, 417 - OEIS A264810, A061070

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4601,10 +4601,10 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A264810", "A061070"]
   formalized:
     state: "no"
-    last_update: "2025-08-31"
+    last_update: "2025-09-04"
   tags: ["number theory"]
 
 - number: "418"


### PR DESCRIPTION
https://www.erdosproblems.com/416
https://www.erdosproblems.com/417

https://oeis.org/A264810
https://oeis.org/A061070

Used the following python script:
```python
def erdos416(x):
	# V(x)
    # count the number of solutions n \le x where \phi(m) = n is solvable
    # since \phi(m) >= sqrt(m/2), we only need to check m <= 2*x^2
    limit = 2 * x^2
    phi_values = set()
    for m in range(1, limit + 1):
        phi_values.add(euler_phi(m))
    count = sum(1 for n in range(1, x + 1) if n in phi_values)
    return count

print([erdos416(x) for x in range(1, 51)])

def erdos417(x):
	# V'(x)
    # size of the set \{\phi(m) : 1 \le m \le x\}
    limit = x
    phi_values = set()
    for m in range(1, limit + 1):
        phi_values.add(euler_phi(m))
    return len(phi_values)

print([erdos417(x) for x in range(1, 51)])
```