### PR TITLE
Change problem status of 993 from 'open' to 'falsifiable'

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10959,7 +10959,7 @@
 - number: "993"
   prize: "no"
   status:
-    state: "open"
+    state: "falsifiable"
     last_update: "2025-09-07"
   formalized:
     state: "no"


### PR DESCRIPTION
993 can be falsified by producing a single graph G for which the independence set counts are not unimodal.