### PR TITLE
Linked A046801 to 893; further addition possible

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -9861,7 +9861,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A046801","possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
The summatory function of A046801 is even more closely tied to 893, but does not appear to be in the OEIS.  If someone volunteers to submit it to the OEIS, it can also be linked to this problem.