### PR TITLE
unlink 528 from A156816

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5833,7 +5833,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A156816"]
+  oeis: ["N/A"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
The sequence https://oeis.org/A156816 represents a number which is merely an approximation of the constant featured in https://www.erdosproblems.com/528. The two constants differ starting from the 11th decimal place.