### PR TITLE
Add OEIS sequences for 985

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10879,7 +10879,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A002233", "A122028", "A241516", "A223942", "A219429", "A103309", "possible"]
+  oeis: ["A002233", "A219429", "A103309", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-09-07"


### PR DESCRIPTION
I added 6 sequences for [985](https://www.erdosproblems.com/985).

The first four (A002233, A122028, A241516, A223942) are almost same, just off by one entry. [A002233](https://oeis.org/A002233) is the smallest prime $q < p_n$ that is a primitive root modulo $p_n$, where the first term is set to be 1. I'm not sure if it worths to add all of them.

[A219429](https://oeis.org/A219429) is the *largest* prime $q < p_n$ that is a primitive root modulo $p_n$.

[A103309](https://oeis.org/A103309) is least prime primitive roots for general modulus, which is defined as 0 when there's no primitive root.