### PR TITLE
Move A388850 from 380 to 382

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4193,7 +4193,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A070003", "A388654", "A387054", "A388850"]
+  oeis: ["A070003", "A388654", "A387054"]
   formalized:
     state: "no"
     last_update: "2025-08-31"
@@ -4215,7 +4215,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["N/A"]
+  oeis: ["A388850"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
[A388850](https://oeis.org/A388850) is more closely related to 382 than to 380.