### PR TITLE
Add A062249 to problem 647.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ There are 1062 problems in total, of which
 - 5 have ambiguous statements.
 - 7 have a literature review requested.
 - 176 have their statements formalized in [Lean](https://lean-lang.org/) in the [Formal Conjectures Repository](https://github.com/google-deepmind/formal-conjectures).
-- 184 have been linked to 226 distinct [OEIS](https://oeis.org/) sequences, with a total of 275 links created.
+- 185 have been linked to 227 distinct [OEIS](https://oeis.org/) sequences, with a total of 276 links created.
   - 21 of these OEIS sequences were added since the creation of this database (A387000 onwards).
 - 338 are potentially related to an [OEIS](https://oeis.org/) sequence not already listed.
-  - 316 of these problems are not currently linked to any existing [OEIS](https://oeis.org/) sequence.
+  - 315 of these problems are not currently linked to any existing [OEIS](https://oeis.org/) sequence.
 - 1 have a related sequence currently being submitted to the [OEIS](https://oeis.org/).
 - 1 have a related sequence whose generation is currently in progress.
 
@@ -681,7 +681,7 @@ There are 1062 problems in total, of which
 | [644](https://www.erdosproblems.com/644) | no | open | no | possible | [combinatorics](https://www.erdosproblems.com/tags/combinatorics) |  |
 | [645](https://www.erdosproblems.com/645) | no | proved | [yes](https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/645.lean) | N/A | [number theory](https://www.erdosproblems.com/tags/number%20theory), [additive combinatorics](https://www.erdosproblems.com/tags/additive%20combinatorics), [ramsey theory](https://www.erdosproblems.com/tags/ramsey%20theory) |  |
 | [646](https://www.erdosproblems.com/646) | no | proved | no | N/A | [number theory](https://www.erdosproblems.com/tags/number%20theory), [factorials](https://www.erdosproblems.com/tags/factorials) |  |
-| [647](https://www.erdosproblems.com/647) | £25 | verifiable | no | possible | [number theory](https://www.erdosproblems.com/tags/number%20theory) |  |
+| [647](https://www.erdosproblems.com/647) | £25 | verifiable | no | [A062249](https://oeis.org/A062249), possible | [number theory](https://www.erdosproblems.com/tags/number%20theory) |  |
 | [648](https://www.erdosproblems.com/648) | no | solved | no | possible | [number theory](https://www.erdosproblems.com/tags/number%20theory) |  |
 | [649](https://www.erdosproblems.com/649) | no | disproved | no | possible | [number theory](https://www.erdosproblems.com/tags/number%20theory) |  |
 | [650](https://www.erdosproblems.com/650) | no | open | no | possible | [number theory](https://www.erdosproblems.com/tags/number%20theory) |  |

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -7147,7 +7147,7 @@
   status:
     state: "verifiable"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A062249", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem 647 is about records of $n+\tau(n)$, where $\tau(n)$ denotes the number of divisors of $n$.  Accordingly, I added sequence A062249, which is precisely "a(n) = n + d(n), where d(n) = number of divisors of n, cf. [A000005](https://oeis.org/A000005)."

I left `"possible"` in the YAML file because there could be closer matches to the problem, eg sequences about the records.  When I was computing the records, which up to 100 occur at
```
1,2,3,4,6,8,10,12,15,16,18,20,24,28,30,35,36,40,42,45,48,54,56,60,66,70,72,78,80,84,90,96,100
```
I was surprised to see that this was only one number (35) away from [A230374](https://oeis.org/A230374).

I guess different notions of "highly composite numbers" are likely to give similar sequences of records.