### PR TITLE
add A110177 to Erdos 1061

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11728,7 +11728,7 @@
   formalized:
     state: "no"
     last_update: "2025-09-28"
-  oeis: ["possible"]
+  oeis: ["A110177", "possible"]
   tags: ["number theory"]
 
 - number: "1062"


### PR DESCRIPTION
Erdos 1061: https://www.erdosproblems.com/1061

A110177: https://oeis.org/A110177

The number of solutions $(a, b)$ is a partial sum of A110177. I used the following Sage script:

```sage
def erdos1061(n):
    # for given n, count the number of solutions (a, b) with 1 \le a, b \le n and a + b \le n such that
    # sigma(a) + sigma(b) = sigma(a + b), where sigma(x) is the sum of divisors of x.
    def sigma(x):
        return sum(d for d in divisors(x))
    count = 0
    for a in range(1, n + 1):
        for b in range(1, n + 1 - a):
            if sigma(a) + sigma(b) == sigma(a + b):
                count += 1
    return count

print([erdos1061(n) for n in range(1, 51)])
```

In fact, [search query](https://oeis.org/search?q=0%2C+0%2C+2%2C+2%2C+2%2C+2%2C+2%2C+4%2C+6%2C+8%2C+8%2C+8%2C+8%2C+8%2C+10%2C+10%2C+10%2C+10%2C+10%2C+12%2C+14%2C+14%2C+14%2C+14%2C+14%2C+14%2C+14%2C+14%2C+14%2C+16%2C+16%2C+20%2C+22%2C+22%2C+22%2C+22%2C+22%2C+22%2C+24%2C+26%2C+26%2C+26%2C+26%2C+26%2C+26%2C+26%2C+26%2C+26%2C+28%2C+28%2C+30%2C+30%2C+30%2C+30%2C+34%2C+36%2C+40%2C+40%2C+40%2C+40%2C+40%2C+42%2C+46%2C+46%2C+46%2C+46%2C+46%2C+46%2C+50%2C+52%2C+52%2C+52%2C+52%2C+52%2C+54%2C+54%2C+54%2C+54%2C+54%2C+54%2C+54%2C+54%2C+54%2C+54%2C+56%2C+56%2C+60%2C+62%2C+62%2C+64%2C+64%2C+66%2C+68%2C+70%2C+70%2C+72%2C+72%2C+72%2C+74%2C+74&language=english&go=Search) actually gives one more sequence [A382856](https://oeis.org/search?q=1%2c3%2c5%2c7%2c9%2c11%2c13%2c15%2c17%2c18%2c19%2c21%2c23%2c25%2c27%2c29%20id:A382856) as terms not appearing in `erdos1061(n)`, although I'm not sure if this is true for all $n$.