### PR TITLE
Added A217693 to #309

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -3410,7 +3410,7 @@
   status:
     state: "disproved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A217693"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
A few notes:
 - the way the OEIS sequence is defined, the sum over the empty set is not considered (i.e. 0 is not considered a valid sum of unit fractions)
 - there are some references on the OEIS page by H. Yokota containing size estimates that are not on the corresponding webpage for this problem that might be worth adding
