### PR TITLE
add A146968 to 936

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10338,7 +10338,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A146968", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
As noted in the comment of [936](https://www.erdosproblems.com/936), the known sequences are all (known) solutions for Brocard's problem. For $2^n \pm 1$, the only solutions up to $n \le 60$ is $9 = 2^3 + 1$.
The conjecture (finiteness) is true under ABC conjecture; see [this](https://arxiv.org/abs/2005.07321) for $2^n \pm 1$ and [this](https://arxiv.org/abs/1611.01192) for factorial (I left a relevant comment on the Erdos website). I found the references with help of GPT-5.