### PR TITLE
Add A160559 to Problem 2

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -17,7 +17,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  oeis: ["N/A"]
+  oeis: ["A160559"]
   tags: ["number theory", "covering systems"]
 
 - number: "3"


### PR DESCRIPTION
[A160559](https://oeis.org/A160559) lists the LCMs of the moduli that occur in minimal covering systems, aligning with [Problem 2](https://www.erdosproblems.com/go_to/2)’s focus on bounds for the smallest modulus in such systems.