### PR TITLE
Add A143824 to Problem 14

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -146,7 +146,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A143824", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
[A143824](https://oeis.org/A143824) gives the maximal size of a Sidon set $A$, which bounds how large $B$ (the integers with a unique sum‑of‑two representation from $A$) can be in [Problem 14](https://www.erdosproblems.com/go_to/14).