### PR TITLE
Add A387053 to Problem 10

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -102,7 +102,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A387053"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
Code to calculate sequence:
```py
import json
import math

with open('primes.json', 'r') as f:
    primes = json.loads(f.read())

def hamming_weight(n: int) -> int:
    return n.bit_count()

a_n = []
for n in range(2, 51):
    # find the prime p <= n such that the hamming weight of n - p is minimized
    min_hw_seen = math.inf
    for p in primes:
        if p > n:
            break
        min_hw_seen = min(min_hw_seen, hamming_weight(n - p))
    a_n.append(min_hw_seen if min_hw_seen != math.inf else 0)

print(a_n)
```
Note that `primes.json` is just a big list of primes, and also this is very likely not the fastest way to calculate this.

Link to OEIS: https://oeis.org/A387053
Link to Erdos Problem: https://www.erdosproblems.com/10

It looks like the author of this sequence in the OEIS cites Erdos Problem 10 as well.