### PR TITLE
Add A390813 to 773

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -8541,7 +8541,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A390813"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Adding Giorgos Kalogeropoulos' now approved [sequence](https://oeis.org/A390813) for [773](https://www.erdosproblems.com/773).