### PR TITLE
Add A390769 to 853

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -9424,7 +9424,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A001223", "possible"]
+  oeis: ["A001223", "A390769"]
   formalized:
     state: "yes"
     last_update: "2025-11-24"


### PR DESCRIPTION
Adding Giorgos Kalogeropoulos' now approved [sequence](https://oeis.org/A390769) for [853](https://www.erdosproblems.com/853).