### PR TITLE
Add A325864 to 1100

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -12154,7 +12154,7 @@
   formalized:
     state: "no"
     last_update: "2025-09-28"
-  oeis: ["possible"]
+  oeis: ["A325864", "possible"]
   tags: ["number theory", "divisors"]
 
 - number: "1101"


### PR DESCRIPTION
A related but not identical OEIS [sequence](https://oeis.org/A325864) for [1100](https://www.erdosproblems.com/1100) according to remark 3 of van Doorn's [comment](https://www.erdosproblems.com/forum/thread/1100#post-1659).