### PR TITLE
Make problem count dynamic in interactive table

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -251,6 +251,17 @@ async function initialize() {
         return;
     }
 
+    // Update header and meta description with actual problem count
+    const problemCount = allProblems.length.toLocaleString();
+    const headerSubtitle = document.getElementById('header-subtitle');
+    if (headerSubtitle) {
+        headerSubtitle.textContent = `Interactive table of ${problemCount} mathematical problems`;
+    }
+    const metaDescription = document.getElementById('meta-description');
+    if (metaDescription) {
+        metaDescription.setAttribute('content', `Interactive table of ${problemCount} mathematical problems from the Erdős problem database`);
+    }
+
     // Set filter change handler FIRST (before creating any event listeners)
     setFilterChangeHandler(updateTable);
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Erdős Problems Database - Interactive Table</title>
-    <meta name="description" content="Interactive table of 1,109 mathematical problems from the Erdős problem database">
+    <meta name="description" content="Interactive table of mathematical problems from the Erdős problem database" id="meta-description">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -12,7 +12,7 @@
         <div class="header-content">
             <div>
                 <h1>Erdős Problems Database</h1>
-                <p>Interactive table of 1,109 mathematical problems</p>
+                <p id="header-subtitle">Interactive table of mathematical problems</p>
                 <p class="subtitle">Data from <a href="https://github.com/teorth/erdosproblems" target="_blank">erdosproblems repository</a></p>
             </div>
             <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">


### PR DESCRIPTION
Follows up on teorth/erdosproblems@24b6811 which removed the hardcoded problem count from `README.md`.

This PR makes the problem count dynamic in the interactive table by:
- Removing hardcoded "1,109" from the header subtitle and meta description in `docs/index.html`
- Dynamically populating these fields after loading the problem data in `docs/app.js`

The count now updates automatically based on the actual data loaded from `problems.yaml`.
