### PR TITLE
chore: Issue template for help wanted issues to get auto labelled with the help wanted label

### DIFF
--- a/.github/ISSUE_TEMPLATE/help-wanted.yml
+++ b/.github/ISSUE_TEMPLATE/help-wanted.yml
@@ -1,0 +1,13 @@
+name: "Help Wanted"
+description: Create a new issue for help wanted
+title: "[Help Wanted] "
+labels: ["help wanted"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Please enter an explicit description
+      placeholder: Explicit description ...
+    validations:
+      required: true


### PR DESCRIPTION
With this issue template, the label gets automatically added instead of manually having to add it as shown below:


https://github.com/user-attachments/assets/aaf10c40-0ccc-4139-a987-3c33b4cf5122