### PR TITLE
Change status of problem 1040 to 'solved'Solution to Problem #1040: μ…

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11487,12 +11487,17 @@
 - number: "1040"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-09-15"
+    state: "solved"
+    last_update: "2025-03"
   formalized:
     state: "no"
     last_update: "2025-09-10"
   oeis: ["N/A"]
+  comments: >-
+    Solved by Krishnapur, Lundberg, and Ramachandran (2025) [arXiv:2503.18270].
+    They proved that for compact sets K with unit capacity, the minimal
+    lemniscate area converges to zero. A scaling argument extends this to
+    capacity > 1. Combined with Erdős-Netanyahu (1973), μ(F) = 0 iff ρ(F) ≥ 1.
   tags: ["analysis"]
 
 - number: "1041"


### PR DESCRIPTION
…(F) = 0 when transfinite diameter ≥ 1

Updated problem 1040 status to 'solved' and added comments.

---

## Summary
Updates Problem #1040 status from `open` to `solved`.

## Reference
Krishnapur, M., Lundberg, E., & Ramachandran, K. (2025). *On the area of polynomial lemniscates*. [arXiv:2503.18270](https://arxiv.org/abs/2503.18270).

## What the paper proves
The KLR paper shows that for any compact set $K$ with transfinite diameter 1, the minimal area of the lemniscate $\{z : |f(z)| < 1\}$ converges to zero as degree $n \to \infty$.

From the abstract:
> "We also consider the minimal area problem under a more general constraint, namely, replacing the unit disc with a compact set K of unit capacity, where we show that the minimal area converges to zero as n → ∞ (giving an affirmative answer to another question of Erdős, Herzog, Piranian)."

## Extension to ρ(F) > 1
A standard scaling argument extends this to capacity > 1: if $\rho(F) = C > 1$, map $F$ to $K = F/C$ (capacity 1), apply KLR, then pull back.

## Complete picture
- ρ(F) < 1: μ(F) > 0 (Erdős-Netanyahu 1973)
- ρ(F) ≥ 1: μ(F) = 0 (KLR 2025)

## Disclosure
This contribution was assisted by AI tools following the [wiki guidelines](https://github.com/teorth/erdosproblems/wiki/AI-contributions-to-Erd%C5%91s-problems). The paper reference and mathematical arguments have been independently verified.
