### PR TITLE
1071: proven (Lean) -> proved (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11833,7 +11833,7 @@
 - number: "1071"
   prize: "no"
   status:
-    state: "proven (Lean)"
+    state: "proved (Lean)"
     last_update: "2026-02-12"
   formalized:
     state: "yes"


### PR DESCRIPTION
It took me a bit to figure out why the statistics chart was showing "96" Lean-formalized solutions, while a search in data/problems.yaml was showing 97 instances of "Lean".