### PR TITLE
Update problem status and last update date for 1014, 1096, and 1198

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11202,8 +11202,8 @@
 - number: "1014"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-09-10"
+    state: "proved"
+    last_update: "2026-04-24"
   formalized:
     state: "no"
     last_update: "2025-09-10"
@@ -12109,8 +12109,8 @@
 - number: "1096"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-10-18"
+    state: "proved"
+    last_update: "2026-04-24"
   formalized:
     state: "no"
     last_update: "2025-09-28"
@@ -13234,8 +13234,8 @@
 - number: "1198"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2026-04-04"
+    state: "disproved"
+    last_update: "2026-04-24"
   formalized:
     state: "no"
     last_update: "2026-04-04"

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11202,7 +11202,7 @@
 - number: "1014"
   prize: "no"
   status:
-    state: "proved"
+    state: "proved (Lean)"
     last_update: "2026-04-24"
   formalized:
     state: "no"


### PR DESCRIPTION
[1014](https://www.erdosproblems.com/1014), [1096](https://www.erdosproblems.com/1096), and [1198](https://www.erdosproblems.com/1198) are all marked as OPEN, yet colored green and resolved on the site.