### PR TITLE
45 -> (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -489,8 +489,8 @@
 - number: "45"
   prize: "no"
   status:
-    state: "proved"
-    last_update: "2025-08-31"
+    state: "proved (Lean)"
+    last_update: "2026-05-06"
   oeis: ["possible"]
   formalized:
     state: "no"


### PR DESCRIPTION
https://www.erdosproblems.com/45 follows black-box from https://www.erdosproblems.com/46 which itself follows from https://www.erdosproblems.com/298 which was formalized by Bloom and Mehta back in 2022.

I have formalized these implications after upgrading that previous proof from Lean3 to Lean4.  For example, here's `erdos45`:
https://github.com/plby/unit-fractions/blob/a18841f8f2803f9680c4a00dc458fbe8d3eb6bda/src4/ErdosProblems.lean#L735-L738