### PR TITLE
Add OEIS to #1204

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13305,7 +13305,7 @@
   formalized:
     state: "no"
     last_update: "2026-04-04"
-  oeis: ["possible"]
+  oeis: ["A008407", "A135311", "possible"]
   tags: ["number theory"]
 
 - number: "1205"

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13305,7 +13305,7 @@
   formalized:
     state: "no"
     last_update: "2026-04-04"
-  oeis: ["A008407", "A135311", "possible"]
+  oeis: ["A008407", "A023193", "A135311", "possible"]
   tags: ["number theory"]
 
 - number: "1205"


### PR DESCRIPTION
[A008407](https://oeis.org/A008407) matches A(k) in problem #1204. OEIS gives the minimum diameter of an admissible k-tuple, which is equivalent to minimizing a_k after shifting the tuple to start at 0.

[A023193](https://oeis.org/A023193) matches the rho-star formulation: the largest size of an admissible tuple inside an interval of a given length, which is the inverse viewpoint for A(k).

[A135311](https://oeis.org/A135311) matches the greedy admissible sequence mentioned in the remarks. I recomputed the first 57 terms and got the same prefix.

I kept "possible" because B(k) may still have a separate OEIS match.