### PR TITLE
Link #295 to A192881

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -3260,7 +3260,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A192881"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
[A192881](https://oeis.org/A192881) "Number of terms for the shortest Egyptian fraction representation of 1 starting with 1/n" matches k(N) in problem #295.

Sanity check: computed k(N) for N = 1..12 by iterative-deepening backtracking with exact rational arithmetic; got 1, 3, 5, 8, 10, 11, 13, 15, 17, 19, 21, 23 -- matches A192881 a(1..12).

(AI-assisted; OEIS match is a known sequence, not a new submission.)