### PR TITLE
Link #1104 to A292528

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -12202,7 +12202,7 @@
   formalized:
     state: "yes"
     last_update: "2025-12-11"
-  oeis: ["possible"]
+  oeis: ["A292528"]
   tags: ["graph theory", "chromatic number"]
 
 - number: "1105"


### PR DESCRIPTION
[A292528](https://oeis.org/A292528) "Minimal number of vertices in a triangle-free graph with chromatic number n" is the inverse function of $f(n)$ in problem #1104 ($f(n)$ = max chromatic number of a triangle-free graph on $n$ vertices). The two encode the same combinatorial structure; $f(n) \geq k$ iff $n \geq$ A292528$(k)$. Known values 1, 2, 5, 11, 22 give $f$ jumps to chromatic numbers 2, 3, 4, 5 at $n = 2, 5, 11, 22$.

(AI-assisted; OEIS match is a known sequence, not a new submission.)