### PR TITLE
Link #555 to A389313

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -6135,7 +6135,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A389313", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
[A389313](https://oeis.org/A389313) "a(n) is the smallest m such that for every red-blue edge-coloring of K_m there exists either a red or a blue n-cycle; Ramsey number r(C_n, C_n)" covers the $k=2$ case of $R_k(C_{2n})$ in problem #555. The even-indexed terms of A389313 are exactly $R_2(C_{2n})$.

"possible" retained because the multicolor ($k \geq 3$) values are not captured by A389313; A389335 covers a 3-color cycle Ramsey but for $r(C_n,C_n,C_n)$ rather than the general $R_k$.

(AI-assisted; OEIS match is a known sequence, not a new submission.)