### PR TITLE
Link #668 to A385657

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -7386,7 +7386,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A385657"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #668 asks whether the number of incongruent point configurations that maximise the unit-distance count tends to infinity (and whether it always exceeds 1 for $n>3$).

[A385657](https://oeis.org/A385657) "Number of nonisomorphic maximally dense unit-distance graphs on n vertices" is a direct match. First terms: 1, 1, 1, 1, 1, 4, 1, 3, 1, 1, 2, 1, 1, 2, 1, 1, 7, 16, 3, 1, 5 — already shows multiple values $>1$ for small $n>3$.

(AI-assisted; OEIS match is a known sequence, not a new submission.)