### PR TITLE
Link #769 to A014544

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -8501,7 +8501,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A014544", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #769 asks for $c(n)$, the minimal threshold such that for all $k \geq c(n)$ the $n$-dimensional unit cube can be decomposed into $k$ homothetic sub-cubes.

[A014544](https://oeis.org/A014544) "Numbers k such that a cube can be divided into k subcubes" is the data set for the $n=3$ case: A014544 lists the achievable values of $k$, and the entries become consecutive starting at 48, which implies $c(3) = 48$ (Hadwiger's problem).

"possible" retained because the higher-dimension values $c(n)$ for $n \geq 4$ are not in OEIS.

(AI-assisted; OEIS match is a known sequence, not a new submission.)