### PR TITLE
Mark Erdős problem 996 as disproved

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11004,8 +11004,8 @@
 - number: "996"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-09-07"
+    state: "disproved"
+    last_update: "2026-05-18"
   formalized:
     state: "yes"
     last_update: "2025-12-22"


### PR DESCRIPTION
Ho, *Counterexamples for lacunary dilates via dyadic spike blocks* (arXiv:2604.18535v2, 2026-04-21), gives a direct negative answer to the displayed question in Problem 996.

Corollary 1.4 states that for every fixed $C>0$, there exist a mean-zero real-valued function

$$
f\in \bigcap_{1\le p<\infty} L^p(\mathbb T)
$$

and a lacunary sequence $(n_j)$ with $n_{j+1}/n_j\ge 2$ such that

$$
\|f-S_Nf\|_2 \ll (\log\log\log N)^{-C}
$$

for all sufficiently large $N$, while

$$
\limsup_{N\to\infty}\frac1N\sum_{j\le N}f(n_jx)=+\infty
$$

for almost every $x$. This directly disproves the existence of the absolute constant $C$ asked for in Problem 996.

This PR updates the unofficial database status from `open` to `disproved`.
