### PR TITLE
Mark Erdős problem 995 as solved

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10993,8 +10993,8 @@
 - number: "995"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-09-07"
+    state: "solved"
+    last_update: "2026-05-18"
   formalized:
     state: "no"
     last_update: "2025-09-07"


### PR DESCRIPTION
Ho, *Counterexamples for lacunary dilates via dyadic spike blocks* (arXiv:2604.18535v2, 2026-04-21), states explicitly that the case $p=2$ answers Problem 995.

For every $\varepsilon>0$, the paper gives examples for which

$$
\limsup_{N\to\infty}
\frac{\sum_{j\le N}f(n_jx)}{N(\log N)^{1/2-\varepsilon}}
=+\infty
$$

almost everywhere. Together with Erdos's general upper bound

$$
\sum_{j\le N} f(n_jx)=o\bigl(N(\log N)^{1/2+\varepsilon}\bigr)
$$

for every $\varepsilon>0$, this pins down the worst-case growth scale at

$$
N(\log N)^{1/2+o(1)}.
$$

Since Problem 995 asks to estimate the growth, this gives a natural resolution of the main question, and in particular disproves the displayed possibility $o(N\sqrt{\log\log N})$.

This PR updates the unofficial database status from `open` to `solved`.
