### PR TITLE
Mark Erdős problem 202 as solved (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -2231,12 +2231,12 @@
 - number: "202"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-08-31"
+    state: "solved (Lean)"
+    last_update: "2026-05-18"
   oeis: ["A389975"]
   formalized:
-    state: "no"
-    last_update: "2025-08-31"
+    state: "yes"
+    last_update: "2026-05-18"
   tags: ["covering systems"]
 
 - number: "203"

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -2235,8 +2235,9 @@
     last_update: "2026-05-18"
   oeis: ["A389975"]
   formalized:
-    state: "yes"
-    last_update: "2026-05-18"
+    state: "no"
+    last_update: "2025-08-31"
+  comments: "external Lean formalization linked in the problem 202 discussion thread"
   tags: ["covering systems"]
 
 - number: "203"


### PR DESCRIPTION
Marks problem 202 as `solved (Lean)` while keeping `formalized` unchanged.

Reason:
- The discussion thread now contains a sharp asymptotic proof of
  `f(N)=N/L(N)^{1+o(1)}`.
- A Lean formalization of the stated result was posted in the thread on
  2026-05-14 and subsequently checked there.
- `formalized` is autogenerated from `formal-conjectures`, so this PR leaves
  that field alone and records the external Lean formalization in `comments`
  instead.

This updates only the detailed crowdsourced status metadata in
`data/problems.yaml`; it does not claim that the official site status has
already changed.