### PR TITLE
Mark Erdős problem 1190 as solved (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13149,9 +13149,10 @@
     state: "solved (Lean)"
     last_update: "2026-05-18"
   formalized:
-    state: "yes"
-    last_update: "2026-05-18"
+    state: "no"
+    last_update: "2026-04-04"
   oeis: ["possible"]
+  comments: "external Lean formalization linked in the problem 202 discussion thread"
   tags: ["number theory", "covering systems"]
 
 - number: "1191"

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13146,11 +13146,11 @@
 - number: "1190"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2026-04-04"
+    state: "solved (Lean)"
+    last_update: "2026-05-18"
   formalized:
-    state: "no"
-    last_update: "2026-04-04"
+    state: "yes"
+    last_update: "2026-05-18"
   oeis: ["possible"]
   tags: ["number theory", "covering systems"]
 


### PR DESCRIPTION
Marks problem 1190 as `solved (Lean)` while keeping `formalized` unchanged.

Reason:
- The sharp asymptotic `epsilon_m = L(m)^{-1+o(1)}` is recorded in the problem
  discussion as a corollary of the sharp result for problem 202.
- The problem 202 thread links a Lean formalization of both the main theorem and
  the 1190 corollary, checked on 2026-05-14.
- `formalized` is autogenerated from `formal-conjectures`, so this PR leaves
  that field alone and records the external Lean formalization in `comments`
  instead.

This updates only the detailed crowdsourced status metadata in
`data/problems.yaml`; it does not claim that the official site status has
already changed.