### PR TITLE
Update problem 90 last update date

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -990,7 +990,7 @@
   prize: "$500"
   status:
     state: "disproved"
-    last_update: "2025-08-31"
+    last_update: "2026-05-20"
   oeis: ["A186705"]
   formalized:
     state: "yes"


### PR DESCRIPTION
The disproof released by OpenAI was on May 20th, 2026.