### PR TITLE
fix: flag problem 983 as ambiguous statement

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10867,6 +10867,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
+  comments: "ambiguous statement"
   tags: ["number theory"]
 
 - number: "984"


### PR DESCRIPTION
## Summary
Flags Erdős problem #983 as having an ambiguous statement in the database metadata.

## Bug
Issue #216 identified a quantifier mismatch between the erdosproblems.com wording and the Erdős–Straus definition of f(k,n): the site reads like a worst-case covering problem over adversarial sets A, while the original theorem uses the reversed quantifiers (choose primes first, then count smooth integers).

## Root cause
The database entry had no indication that the published problem statement may not match the literature formulation discussed in #216.

## Why this fix is correct
Per CONTRIBUTING.md, `comments: "ambiguous statement"` marks problems whose intended statement is uncertain or differs from a literal reading. This matches the resolution in #216 without changing the external problem page text.

Fixes #216

## Test plan
- [ ] CI regenerates README from `data/problems.yaml`

Made with [Cursor](https://cursor.com)