### PR TITLE
Add OEIS sequences (A193838, A271490) to problem #1208

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13349,7 +13349,7 @@
   formalized:
     state: "no"
     last_update: "2026-04-04"
-  oeis: ["possible"]
+  oeis: ["A193838", "A271490", "possible"]
   tags: ["geometry", "distances"]
 
 - number: "1209"


### PR DESCRIPTION
### OEIS link for #1208 (integer-lattice distinct-distance subset)

Adds two OEIS sequences to the `oeis` field of problem **#1208** (currently `["possible"]`, i.e. no sequence listed):

- **[A193838](https://oeis.org/A193838)** — *Size k of smallest k×k lattice square from which n points with pairwise distinct distances can be chosen* (the main OEIS entry for this problem).
- **[A271490](https://oeis.org/A271490)** — *Size of the maximal subset of the n×n grid with all pairwise distances distinct* (the inverse function).

**Why these belong on #1208.** The remark on the problem page explicitly discusses this integer-lattice sub-problem: *"Erdős and Guy [ErGu70] consider the problem of determining the maximal size of such a subset of the n^{1/d}×⋯×n^{1/d} integer grid…"*. Both A193838 and A271490 cite exactly that reference — P. Erdős and R. K. Guy, *Distinct distances between lattice points*, Elem. Math. 25 (1970), 121–123 — so they are the OEIS sequences for the d=2 case of the construction that furnishes the upper bound F_d(n) ≪ n^{1/d}. A researcher working on #1208 would plausibly want this data.

I kept `"possible"` in the field, since further related sequences exist/could be added (e.g. the higher-dimensional grid analogues, and [A335232](https://oeis.org/A335232) counting optimal solutions).

**Independent verification.** I recomputed A271490 from scratch by exhaustive search over the k×k grid (largest subset with all pairwise squared-distances distinct), verifying each witness has distinct points and distinct distances. The first terms match A271490 exactly:

```
k       : 1 2 3 4 5 6 7 8 9 10
G2(k)   : 1 2 3 4 5 6 7 7 8 9   (k≤8 exact; k=9,10 confirmed as ≥, matching A271490)
```

This does **not** resolve #1208, which remains open; it only links the relevant lattice-subproblem sequences.

*Disclosure: this contribution (literature/OEIS search and the verification code) was prepared with AI assistance; the sequence values were independently recomputed and checked against OEIS, and the relevance was verified against the primary reference [ErGu70].*
