### PR TITLE
fix: link OEIS sequences for problem #1208

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -13349,7 +13349,7 @@
   formalized:
     state: "no"
     last_update: "2026-04-04"
-  oeis: ["possible"]
+  oeis: ["A193838", "A271490", "possible"]
   tags: ["geometry", "distances"]
 
 - number: "1209"


### PR DESCRIPTION
## Summary
Adds the verified OEIS sequences for the integer-lattice distinct-distance subproblem of #1208.

## Bug
Problem #1208 only had `oeis: ["possible"]` even though the relevant sequences A193838 and A271490 are in the OEIS and cite Erdős–Guy [ErGu70], the same reference discussed on the problem page for the d=2 grid case.

## Root cause
The database entry was never updated after the sequences were identified and independently recomputed.

## Why this fix is correct
Both sequences match the lattice formulation in issue #318; A271490 terms were recomputed and checked against OEIS.

Fixes #318


Made with [Cursor](https://cursor.com)