### PR TITLE
fix: update status last_update for problem 619

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -6841,7 +6841,7 @@
   prize: "no"
   status:
     state: "solved"
-    last_update: "2025-08-31"
+    last_update: "2026-06-13"
   oeis: ["N/A"]
   formalized:
     state: "yes"


### PR DESCRIPTION
## Summary
- Problem #619 is marked `solved` but `status.last_update` was still `2025-08-31`.

## Root cause
The status timestamp was not refreshed when the Lean formalization landed (`formalized.last_update: 2026-06-13`), so the database reports the problem as solved as of the bulk-import date.

## Fix
Set `status.last_update` to `2026-06-13`, matching the formalization update.

## Test plan
- [ ] README regeneration shows #619 solved with updated date


Made with [Cursor](https://cursor.com)