### PR TITLE
fix: update status last_update for problems 716 and 986

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -7914,7 +7914,7 @@
   prize: "no"
   status:
     state: "proved (Lean)"
-    last_update: "2025-08-31"
+    last_update: "2026-06-16"
   oeis: ["possible"]
   formalized:
     state: "no"

--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10895,7 +10895,7 @@
   prize: "no"
   status:
     state: "proved"
-    last_update: "2025-08-31"
+    last_update: "2026-06-21"
   oeis: ["A000791", "A059442"]
   formalized:
     state: "no"


### PR DESCRIPTION
## Summary
- #716 is `proved (Lean)` and #986 is `proved`, but both still had `status.last_update: 2025-08-31`.

## Root cause
#716 was upgraded on 2026-06-16 and #986 on 2026-06-21; the timestamps were never refreshed, so the table reports those statuses as of the bulk-import date.

## Fix
Set `status.last_update` to the actual status-change dates.

## Test plan
- [ ] README regeneration shows updated dates for #716 and #986