### PR TITLE
fix: update status last_update for problem 986

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10895,7 +10895,7 @@
   prize: "no"
   status:
     state: "proved"
-    last_update: "2025-08-31"
+    last_update: "2026-06-21"
   oeis: ["A000791", "A059442"]
   formalized:
     state: "no"


### PR DESCRIPTION
## Summary
- Problem #986 is marked `proved` but `status.last_update` was still `2025-08-31`.

## Root cause
The status changed from `open` to `proved` on 2026-06-21, but the timestamp was not updated, so the database still reports it as proved as of the bulk-import date.

## Fix
Set `status.last_update` to `2026-06-21`.

## Test plan
- [ ] README regeneration shows #986 with updated date


Made with [Cursor](https://cursor.com)