### PR TITLE
fix: note external Lean companion formalization for problem 887

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -9808,6 +9808,7 @@
   formalized:
     state: "yes"
     last_update: "2026-01-13"
+  comments: "preprint doi.org/10.5281/zenodo.20651083; Lean companion formalization github.com/jarekkoch-hub/erdos887-lean"
   tags: ["number theory", "divisors"]
 
 - number: "888"


### PR DESCRIPTION
## Summary
Adds a `comments` field to problem #887 recording the preprint and external Lean companion formalization described in #319.

## Bug
Problem #887 had no database note of the external Lean companion repo or preprint, even though CONTRIBUTING.md specifies that formalizations outside the formal-conjectures repository should be recorded in `comments`.

## Root cause
The entry was never updated after the companion artifacts were published in June 2026.

## Why this fix is correct
Per CONTRIBUTING.md, external formalization locations belong in `comments` rather than the autogenerated `formalized` field. Status remains `open` pending external review, matching option 2 discussed in #319.

Fixes #319

## Test plan
- [x] `python scripts/validate.py` passes
- [ ] CI regenerates README from `data/problems.yaml`

Made with [Cursor](https://cursor.com)