### PR TITLE
Add OEIS A397205 link for Erdős problem #490

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5411,7 +5411,7 @@
   status:
     state: "proved (Lean)"
     last_update: "2026-05-22"
-  oeis: ["N/A"]
+  oeis: ["A397205"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
This updates the OEIS field for Erdős problem #490 from N/A to A397205.

A397205 records the maximum value of |S|*|T| over subsets S,T of {1,...,n}
such that the products s*t are pairwise distinct. This is directly connected
to problem #490, which concerns product-distinct pairs of subsets of [N].

The discussion thread for #490 also notes that the corresponding sequence of
largest products |A||B| would be a useful addition to OEIS.

Links:
- OEIS A397205: https://oeis.org/A397205
- Erdős problem #490: https://www.erdosproblems.com/490
- Discussion thread: https://www.erdosproblems.com/forum/thread/490
- Verification code/table: https://github.com/KitaKen1/product-distinct-pairs-erdos490
- Visual dashboard: https://kitaken1.github.io/product-distinct-pairs-erdos490/