### PR TITLE
884: mark disproof as formalized in Lean — disproved (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -9769,8 +9769,8 @@
 - number: "884"
   prize: "no"
   status:
-    state: "disproved"
-    last_update: "2026-03-28"
+    state: "disproved (Lean)"
+    last_update: "2026-07-03"
   oeis: ["N/A"]
   formalized:
     state: "yes"


### PR DESCRIPTION
Updates the status of Erdős problem **#884** from `disproved` to `disproved (Lean)`: the unconditional disproof has now been formalized and machine-verified in Lean 4 / Mathlib.

**Problem.** For $n$ with divisors $1 = d_1 < \dots < d_{\tau(n)} = n$, Erdős conjectured
$\sum_{i<j} \frac{1}{d_j - d_i} \ll 1 + \sum_i \frac{1}{d_{i+1} - d_i}$ as $n \to \infty$. Daniel Larsen [gave an unconditional disproof](https://github.com/Larsen-Daniel/Erdos-884/blob/main/884.pdf) (building on Tao's conditional construction).

**Formalization.** Larsen's disproof is formalized at [honicky/erdos884](https://github.com/honicky/erdos884). The main theorem `erdos_884_iff_false` proves `False ↔ (sumDivisorInvPairwiseDifference =O[Filter.atTop] (1 + sumDivisorInvConsecutiveDifference))`, matching the statement in [google-deepmind/formal-conjectures `ErdosProblems/884.lean`](https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/884.lean) (`answer(False) ↔ Erdos884Prop`, with `answer`/`≪` unfolded).

**Verification.** 0 errors, 0 `sorry`, and `#print axioms` = `[propext, Classical.choice, Quot.sound]` (standard axioms only), reproduced two independent ways:
- offline `lake build` against Mathlib `v4.31.0`, and
- the [Axle](https://axle.axiommath.ai) hosted Lean engine.

A companion PR links the proof from formal-conjectures: google-deepmind/formal-conjectures#4391.

Only the `status` of entry #884 is changed (`state` and `last_update`); the `formalized` field (statement formalization) is unchanged.
