### PR TITLE
Link problem 448 to OEIS A397433

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4947,7 +4947,7 @@
   status:
     state: "disproved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A397433"]
   formalized:
     state: "yes"
     last_update: "2026-06-23"


### PR DESCRIPTION
Problem 448 concerns the function tau^+(n) = number of dyadic blocks [2^k, 2^(k+1)) containing at least one divisor of n. This sequence is now in the OEIS as A397433 (https://oeis.org/A397433), which I submitted and which was published on 2026-07-03. This PR adds it to the `oeis` field for problem 448 (replacing the "possible" placeholder).