### PR TITLE
Link #1139 to OEIS A037143 and A101041

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -12589,7 +12589,7 @@
   formalized:
     state: "yes"
     last_update: "2026-01-28"
-  oeis: ["possible"]
+  oeis: ["A037143", "A101041"]
   tags: ["number theory", "primes"]
 
 - number: "1140"


### PR DESCRIPTION
## What

Links problem **#1139** to its two natural OEIS sequences:

```diff
-  oeis: ["possible"]
+  oeis: ["A037143", "A101041"]
```

#1139 concerns `1 ≤ u_1 < u_2 < ⋯`, the integers with at most 2 prime factors
(Ω(n) ≤ 2, counted with multiplicity):
- **A037143** — the sequence u_k itself ("Numbers with at most 2 prime factors
  (counted with multiplicity)").
- **A101041** — its counting function, #{m ≤ n : Ω(m) ≤ 2} ("Number of numbers not
  greater than n having no more than two prime factors"), the inverse enumeration.

## Why drop `possible`

Both natural associated sequences (the enumeration and its counting function) are now
linked. The remaining candidate — the gap sequence `u_{k+1} − u_k`, most relevant to
the limsup question — is **not** in the OEIS, so there is no further *existing* OEIS
match to flag. (It could be a future new-sequence submission.)

## Verification

- Each sequence was computed **two independent ways** (a smallest-prime-factor sieve
  and `sympy.factorint`) that agree, and each matches the OEIS entry **exactly over 50
  terms** (A037143 stores 69 terms, A101041 stores 73; the first 50 coincide).
- The repo validator (`scripts/validate.py`) passes on the edited file.

## Disclosure

Prepared with **AI assistance (Claude Code)**: the AI wrote the computation code and
located the OEIS matches; the terms were independently cross-checked (two methods per
sequence + the exact OEIS matches), per CONTRIBUTING.md's guidance on AI tools. This
only **links existing** OEIS sequences — there is no new OEIS submission involved.
