### PR TITLE
Link #222 to A001481 (sum of two squares)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -2454,7 +2454,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A256435"]
+  oeis: ["A001481", "A256435"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #222 concerns the sequence $n_1 < n_2 < \cdots$ of integers that are the sum of two squares, and the behaviour of its consecutive gaps.

The gap sequence is already linked (**A256435**, first differences of sums of two squares), but the underlying **set itself** was not. This PR adds it:

- **[A001481](https://oeis.org/A001481)** — Numbers that are the sum of two squares.

This mirrors the linking on the closely analogous problem **#208** (gaps between *squarefree* numbers), which links both the set (A005117) and its gaps (A076259).

Verification: membership was computed two independent ways — (i) the Fermat criterion (every prime $p \equiv 3 \pmod 4$ divides $n$ to an even power) and (ii) a direct brute-force search for $n = u^2 + v^2$ — and the two agree with each other and with A001481's OEIS b-file over the full overlap (66 terms, sets identical).

*Disclosure: this contribution was prepared with AI assistance (computation and OEIS cross-checking); all sequence terms were verified against the definition and against OEIS by the submitter. No new OEIS sequence was created — this only links an existing one.*
