### PR TITLE
Link #940 to OEIS r-powerful sequences (A036966/A036967/A069492)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10388,7 +10388,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A036966", "A036967", "A069492"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #940 defines, for each $r \geq 3$, the **$r$-powerful numbers** (a number $n$ such that for every prime $p \mid n$ we have $p^r \mid n$) and asks about sums of at most $r$ of them.

The defining sets are classical and already in the OEIS. This PR links them:

- **[A036966](https://oeis.org/A036966)** — 3-full (cubefull) numbers ($r = 3$)
- **[A036967](https://oeis.org/A036967)** — 4-full numbers ($r = 4$)
- **[A069492](https://oeis.org/A069492)** — 5-full numbers ($r = 5$)

Verification: membership was computed two independent ways — (i) `sympy.factorint` and (ii) a hand-rolled trial-division factorization — requiring the minimum prime exponent to be $\geq r$. The two agree with each other and with each OEIS entry over the full overlap (48/40/37 terms respectively; sets identical).

*Disclosure: prepared with AI assistance (computation and OEIS cross-checking); all terms verified against the definition and against OEIS by the submitter. No new OEIS sequence was created — this only links existing ones.*
