### PR TITLE
Link #456 to A034694 and A061026 (least prime =1 mod n; least m with n | phi(m))

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5035,7 +5035,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A034694", "A061026", "possible"]
   formalized:
     state: "yes"
     last_update: "2026-06-07"


### PR DESCRIPTION
Problem #456 studies two integer sequences and their comparison:

- $p_n$ = the smallest prime $\equiv 1 \pmod n$;
- $m_n$ = the smallest integer $m$ with $n \mid \phi(m)$,

asking (among other things) whether $m_n < p_n$ for almost all $n$, and whether $p_n/m_n \to \infty$. Both sequences are already in the OEIS but were not yet linked here:

- **[A034694](https://oeis.org/A034694)** — Smallest prime $\equiv 1 \pmod n$  ($= p_n$).
- **[A061026](https://oeis.org/A061026)** — Smallest $m$ such that $\phi(m)$ is divisible by $n$  ($= m_n$).

Verification: each sequence was computed two independent ways and the two agree over all 64 terms.

- $p_n$: (i) testing the arithmetic progression $1+n, 1+2n, \ldots$ for primality, vs (ii) walking the primes in increasing order and filtering by residue.
- $m_n$: (i) per-value Euler totient ($\phi$ by factorization), vs (ii) a totient sieve.

The computed terms match **A034694** exactly (all 62 terms stored there) and **A061026** exactly (all 64 terms). As a sanity check, the invariant $m_n \le p_n$ — which must hold since $\phi(p_n) = p_n - 1$ is divisible by $n$ — is satisfied across all computed terms.

I have kept the `"possible"` tag, as a further sequence may be associated with the third question (primes $p$ for which $p-1$ is the only $n$ with $m_n = p$).

*Disclosure: this contribution was prepared with AI assistance (computation and OEIS cross-checking); all sequence terms were verified against the definition and against the OEIS by the submitter. No new OEIS sequence was created — this only links two existing ones.*
