### PR TITLE
Link #938 to A076446 (differences of consecutive powerful numbers)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -10366,7 +10366,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A001694", "possible"]
+  oeis: ["A001694", "A076446", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #938 concerns the sequence $n_1 < n_2 < \cdots$ of **powerful numbers** (if $p \mid n$ then $p^2 \mid n$), asking whether there are only finitely many three-term arithmetic progressions among *consecutive* terms $n_k, n_{k+1}, n_{k+2}$ — equivalently, finitely many $k$ with $n_{k+1} - n_k = n_{k+2} - n_{k+1}$.

The **set itself** is already linked (**A001694**), but the statistic this problem actually asks about — the **gaps between consecutive powerful numbers**, whose consecutive equal values are exactly the sought progressions — was not. This PR adds it:

- **[A076446](https://oeis.org/A076446)** — Differences of consecutive powerful numbers.

Linking both the set and its gaps matches the existing treatment of the analogous problem **#208** (squarefree numbers), which lists both the set A005117 and its gaps A076259.

Verification: the gaps were computed two independent ways — (i) a smallest-prime-factor sieve testing that every prime exponent of $n$ is $\ge 2$, and (ii) the constructive enumeration of all $a^2 b^3$ — which agree on all 2026 gaps for powerful numbers up to $10^6$, and match **A076446** exactly over all 76 terms stored there. As a concrete check of the object studied, the first consecutive-equal-gap positions give the AP triples $1728, 1764, 1800$ (common difference $36$) and $6912, 7056, 7200$ (difference $144$), each term verified powerful by hand-factorisation.

I have kept the `"possible"` tag: the counting function of the set, and the sequence of AP-triple starts (which is not currently in the OEIS), remain plausible future additions.

*(AI-assisted: computation and OEIS cross-checking; all terms independently verified against the definition and the OEIS. This links an existing sequence — no new OEIS submission.)*
