### PR TITLE
Link #325 to A004825, A004832, A004843 (numbers that are sums of three k-th powers, k=3-5)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -3590,7 +3590,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A004825", "A004832", "A004843", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problem #325 concerns $f_{k,3}(x)$, the number of integers $\leq x$ that are the sum of three nonnegative k-th powers, asking whether $f_{k,3}(x)\gg x^{3/k}$ (or $\gg_\epsilon x^{3/k-\epsilon}$) for each $k\geq 3$. So $f_{k,3}$ is exactly the **counting function of the set** $S_k=\{a^k+b^k+c^k : a,b,c\geq 0\}$, and the sequence naturally associated to the problem is the enumeration of $S_k$.

The problem is a two-variable quantity in $(k,x)$. Specializing $k$ to its first values gives an explicit set for each $k$, and these are already in the OEIS (note "sum of at most 3 positive k-th powers" is the same set, since $0=0^k$ fills any unused summand):

- **[A004825](https://oeis.org/A004825)** — $k=3$, numbers that are the sum of at most 3 positive cubes.
- **[A004832](https://oeis.org/A004832)** — $k=4$, sum of at most 3 nonzero 4th powers.
- **[A004843](https://oeis.org/A004843)** — $k=5$, sum of at most 3 positive 5th powers.

```diff
-  oeis: ["possible"]
+  oeis: ["A004825", "A004832", "A004843", "possible"]
```

Linking one sequence per specialized $k$ is established practice — e.g. problems #3, #139, #142 and #201 link the family A003002/A003003/A003004/A003005 (largest subset of $[1,n]$ with no $k$-term arithmetic progression). Following CONTRIBUTING.md's suggestion to specialize a two-variable quantity "e.g. $k=1,2,3$" as examples, I have linked the first three cases $k=3,4,5$. The OEIS carries this family further (k=6 is [A004854](https://oeis.org/A004854), k=7 is [A004865](https://oeis.org/A004865), and so on), and I'm happy to add higher $k$ if you would prefer the complete run.

**Verification.** Each set was computed two independent ways — (i) a direct triple loop over $a^k+b^k+c^k$, and (ii) a 3-fold Minkowski sum of the k-th-power indicator computed purely by bit-shift/OR on a big integer, which shares no arithmetic with (i) — and the two agree on every term (316 / 134 / 76 terms for $k=3/4/5$). Each matches its OEIS entry exactly over **all** terms stored there (59, 47, 49 respectively), and the first values were checked against the definition by hand (e.g. $k=3$: $8=2^3$, $16=2^3+2^3$, $27=3^3$, $35=3^3+2^3$; $k=5$: $64=2^5+2^5$, $243=3^5$, $275=3^5+2^5$). (I have verified $k=6$/A004854 the same way in case you would like it added.)

I have kept the `"possible"` tag: the problem's actual object is the counting function $f_{k,3}(x)$ itself (not currently in the OEIS) for all $k\geq 3$, so further sequences — the counting functions, or higher $k$ — remain plausible future additions.

*(AI-assisted: an AI wrote the computation code and located the OEIS matches; every term was independently cross-checked (two methods per sequence, exact agreement with the OEIS, and hand-verification against the definition), per CONTRIBUTING.md's guidance on AI tools. This only links existing OEIS sequences — no new OEIS submission is involved.)*
