### PR TITLE
768 proven (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -8488,8 +8488,8 @@
 - number: "768"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-08-31"
+    state: "proved (Lean)"
+    last_update: "2026-07-14"
   oeis: ["A001034", "A352287"]
   formalized:
     state: "no"


### PR DESCRIPTION
768 is proven by Eric Li in https://arxiv.org/pdf/2606.24872, along with an Aristotle formalisation in [ericlisg/erdos768-lean](https://github.com/ericlisg/erdos768-lean).
The code also passes [comparator](https://github.com/leanprover/comparator) in [this run](https://github.com/intgrah/erdos768-lean/actions/runs/29299381761/job/86979759747). The statement also appears to be a correct translation of the problem.
