### PR TITLE
469 -> proved (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5178,8 +5178,8 @@
 - number: "469"
   prize: "no"
   status:
-    state: "open"
-    last_update: "2025-08-31"
+    state: "proved (Lean)"
+    last_update: "2026-07-21"
   oeis: ["A006036", "A119425", "possible"]
   formalized:
     state: "yes"


### PR DESCRIPTION
I have personally verified that the Lean formalization originally posted at https://www.erdosproblems.com/forum/thread/469/proof-claims is correct.

Specifically, I have imported it into my repository and set up Comparator.  The problem statement was already available in the Formal Conjectures project at https://github.com/google-deepmind/formal-conjectures/blob/main/FormalConjectures/ErdosProblems/469.lean

The Comparator challenge file (which matches the Formal Conjectures setup) can be viewed in isolation here: https://github.com/plby/lean-proofs/blob/main/src/latest/ComparatorChallenges/ErdosProblems/Erdos469.lean