### PR TITLE
1112 -> open (Lean)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -18036,7 +18036,9 @@
     state: "open"
     last_update: "2025-12-28"
   formal_status:
-    state: "unformalized"
+    state: "Lean"
+    last_update: "2026-07-25"
+    url: "https://github.com/beetree/math_erdos_1112"
   status:
     state: "open"
     last_update: "2025-12-28"


### PR DESCRIPTION
Following the split introduced in #350, I believe this is the right way to record a
formalized solution: set `formal_status.state` to `Lean` with a `url`, leave
`informal_status` at `open`, and leave the derived `status` alone. That yields
`open (Lean)`. Please tell me if I've got any of it wrong as this is my first
contribution here, and I think it may be the first entry to use that combination.

**The work.** Everything is in one repository:
<https://github.com/beetree/math_erdos_1112>

- The Lean 4 formalization. The problem is transcribed into a frozen statement file
  (`lean/Erdos1112.lean`), and the README's "Why this encoding is faithful" section
  argues clause by clause that the encoding says what the original problem ask, as documented on erdosproblems.com/1112. The
  development is `sorry`-free, uses no `native_decide`, and `#print axioms` reports
  only `propext`, `Classical.choice`, `Quot.sound`. The README gives a one-command
  way to rebuild it.
- A paper with the human-readable proof, and an appendix mapping each result to the
  Lean declaration that checks it.
- The result: `r_k(d₁,d₂)` exists **iff** `d₂ ≥ k+1`, with `r_k ≤ 192·d₂` above the
  threshold and non-existence below it in a strong form.

**Prior review.** This was posted on erdosproblems.com on 6 July, about three weeks
ago, and has since had two endorsements of the *formalization*:

- Thomas Bloom (13 July) verified that `erdos_1112` in `Erdos1112Proof/Final.lean`
  is a correct formalisation of the problem as stated on the site, and that it
  compiles with no `sorry`. He noted explicitly that he had not attempted to follow
  the mathematics itself.
- Colin Snyder (17 July) rebuilt the development from scratch on his own machine,
  confirmed the kernel accepts the final theorems on the three standard axioms with
  no `sorry` and no `native_decide`, ran both Python verification harnesses, and
  checked the certificate tables against their published SHA-256 digests.

**I am deliberately not claiming `informal_status`.** I believe the mathematics is
correct, but there has been no third-party human review of the argument itself -
both endorsements above are of the formalization, not the proof. That is exactly the
situation `open (Lean)` was introduced for in #350, so I have left `informal_status`
untouched at `open`.

**AI disclosure.** The proof, the Lean development and a first draft of the paper
were produced with substantial assistance from automated systems, under my direction
and audit. The paper states the division of labour in full. The systems are tools,
not authors; I take responsibility for the content.

**Validation.** I ran this repository's own scripts against the change:
`scripts/validate.py --base <upstream main>` passes, reporting only the expected
notice that `status` is stale and will be regenerated as `open (Lean)`;
`scripts/derive_status.py` confirms that is what it derives. The diff touches three
lines of `data/problems.yaml` and nothing else.