### PR TITLE
OEIS: link A121269 to problem 877 and A347025 to problem 1023

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -14233,7 +14233,7 @@
   status:
     state: "proved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A121269", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"
@@ -16599,7 +16599,7 @@
   formalized:
     state: "no"
     last_update: "2025-09-10"
-  oeis: ["possible"]
+  oeis: ["A347025", "possible"]
   tags: ["combinatorics"]
 
 - number: "1024"


### PR DESCRIPTION
Two problems flagged `oeis: ["possible"]` with no sequence attached now have a
confirmed match.

### [877] — number of maximal sum-free subsets of $\{1,\dots,n\}$ → **A121269**

The problem defines $f_m(n)$ as the number of maximal sum-free subsets
$A\subseteq\{1,\dots,n\}$. Computed values:

| n | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 |
|---|---|---|---|---|---|---|---|---|---|---|----|----|----|
| f_m(n) | 1 | 1 | 2 | 2 | 4 | 5 | 6 | 8 | 13 | 17 | 23 | 29 | 37 |

[A121269](https://oeis.org/A121269) "Number of maximal sum-free subsets of
{1,2,...,n}" has exactly this data.

**Offset.** A121269 has offset 0, and the table above is $a(0)\ldots a(12)$ — the
leading $a(0)=1$ is the empty set, which is vacuously maximal sum-free in
$\{1,\dots,0\}=\emptyset$. Reading the terms as starting at $n=1$ would shift them
by one and make the match look wrong, so stating this explicitly: the alignment is
$f_m(n)=$ A121269$(n)$ for $n\ge 0$. (A121269 carries a b-file to $n=80$, so no
extension of terms is needed here.)

**"Sum-free" convention.** The match is with the standard convention that
$a=b+c$ is forbidden **including** $b=c$ (i.e. $b\in A$ with $2b\in A$ is
disallowed). The strict variant $b\neq c$ gives a different sequence, which does
not appear to be in the OEIS. Correspondingly, the maximality test has three cases
— $x=b+c$, $a=x+b$, and $2x\in A$ — and omitting the third silently produces a
different but entirely plausible-looking sequence.

### [1023] — largest family with no member a union of others → **A347025**

$F(n)$ is the maximal size of a family of subsets of $\{1,\dots,n\}$ in which no
member is the union of other members. Computed values:

| n | 0 | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|---|
| F(n) | 0 | 1 | 2 | 4 | 7 | 13 |

[A347025](https://oeis.org/A347025) "Maximum size of a family of **nonempty** sets
on n elements such that no set is a union of some others" is
`0, 1, 2, 4, 7, 13, 24, 44` (offset 0).

**On the nonempty restriction — being explicit, since this is a convention choice
rather than something the problem statement forces.** The problem says "family of
subsets of $\{1,\dots,n\}$", which strictly speaking admits $\emptyset$; A347025
excludes it. The two readings differ by *exactly one*, always:

* If $\emptyset$ is regarded as the union of the empty subfamily, it can never be
  a member, and the two definitions coincide.
* If instead "union of other members" is read as requiring at least one other
  member, then $\emptyset$ is always admissible, and adding it to any optimal
  family is always legal — no other member $S$ can become a union of others,
  since $\emptyset\cup T_1\cup\cdots = T_1\cup\cdots$. So that variant is exactly
  $F(n)+1$, giving `2, 3, 5, 8, 14`, which is not in the OEIS.

Either way the asymptotic question actually asked — whether
$F(n)\sim c\,2^n/n^{1/2}$ — is unaffected. I've matched against the nonempty
reading because it is the one under which the sequence is standard, but flagging
the choice rather than burying it.

### Verification

Both sequences were computed, then **re-derived by a second, independently written
exhaustive brute force**:

* 877 — enumerate all $2^n$ subsets of $\{1,\dots,n\}$, filter sum-free, keep those
  not properly contained in another sum-free set. Agrees for $n\le 12$.
* 1023 — enumerate all $2^{2^n-1}$ families of nonempty subsets for $n\le 4$
  (agrees: `0,1,2,4,7`), plus a structurally different DFS for $n\le 5$
  (agrees: `0,1,2,4,7,13`).

`python scripts/validate.py` → `✅ Validation OK.`

### On `"possible"`

Kept in both entries, since further sequences may reasonably be added later (e.g.
the strict sum-free variant for 877, and the $\emptyset$-inclusive variant for
1023).

---

*Disclosure: this contribution was prepared with AI assistance (GitHub Copilot CLI).
The search/brute-force code was written by the assistant; every claimed value was
cross-checked against an independently written exhaustive enumeration, and only the
`oeis` fields of `data/problems.yaml` are touched. No sequence is being submitted to
the OEIS on the basis of this work.*
