### PR TITLE
Problem 252: add OEIS A307036 and A359060 (k = 3, 4); retain possible flag

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4087,7 +4087,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A227988", "A227989", "possible"]
+  oeis: ["A227988", "A227989", "A307036", "A359060", "possible"]
   formalized:
     state: "yes"
     last_update: "2026-01-03"


### PR DESCRIPTION
Problem #252 concerns the irrationality of $S_k = \sum_{n \ge 1} \sigma_k(n)/n!$. The entry already links $k = 1$ and $k = 2$. This adds the $k = 3$ and $k = 4$ constants. The `"possible"` flag is **retained**, since $k \ge 5$ is not covered (see below).

| k | OEIS | `name` field, quoted verbatim |
|---|---|---|
| 1 | [A227988](https://oeis.org/A227988) | Decimal expansion of Sum_{n >= 1} sigma_1(n)/n!. |
| 2 | [A227989](https://oeis.org/A227989) | Decimal expansion of Sum_{n >= 1} sigma_2(n)/n!. |
| 3 | [A307036](https://oeis.org/A307036) | Decimal expansion of Sum_{k >= 1} sigma_3(k)/k!, where sigma_3(k) is the sum of cubes of the divisors of k (A001158). |
| 4 | [A359060](https://oeis.org/A359060) | Decimal expansion of Sum_{n >= 1} sigma_4(n)/n!. |

The `name` fields are quoted verbatim so that functional equivalence with the problem statement can be judged without recomputation.

### Verification

Each constant was computed **two independent ways**, both as exact rationals over 120 terms:

- **(A)** direct $\sum \sigma_k(n)/n!$, with $\sigma_k$ obtained by trial division;
- **(B)** the rearrangement $\sum_d d^k \sum_j 1/(jd)!$, which swaps the order of summation and so shares no code path with (A).

The two agree exactly on 40 truncated significant digits for every $k \in \{1,\dots,6\}$.

Each was then compared against the live OEIS `data` field, comparing **truncated** rather than rounded digits (see the companion issue #357):

| k | A-number | agreement |
|---|---|---|
| 1 | A227988 | exact over **87** digits |
| 2 | A227989 | exact over **87** digits |
| 3 | A307036 | exact over **87** digits |
| 4 | A359060 | exact over **81** digits |

An 80-digit agreement rules out coincidence, so identity is settled; the `name` quotes above are supplied so that the separate question of *functional equivalence of description* can be checked directly.

Code: stdlib-only apart from an optional `urllib` OEIS fetch, and it runs in well under a minute. It is reproduced in a comment below so it can be inspected and re-executed rather than taken on trust.

### Why `"possible"` stays

$S_5$ and $S_6$ are **not** in the OEIS. By CONTRIBUTING.md's rule ("If you believe that there are still further sequences related to this problem that could be added in the future, keep the `possible` string"), the flag should therefore remain: the family is demonstrably incomplete.

I am deliberately **not** proposing an OEIS submission for them, since per the project's AI policy any OEIS submission must be human-originated. Recording the truncated values here only so the gap is visible to anyone who wants to pursue it:

```
S_5 = 143.8119639327382460893906480919610538206...
S_6 = 556.4071645455845889451656064554874344282...
```

### AI disclosure

This PR was prepared with AI assistance (GitHub Copilot CLI). No sequence values were taken from a model: all figures come from code that was written, inspected and executed locally, and every constant was reproduced by two independent methods before being compared to OEIS. Nothing here is proposed for submission to the OEIS.
