### PR TITLE
Problems 323, 325: link the A004825-A004869 sums-of-kth-powers block (20 cells verified)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5240,7 +5240,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A004825", "A004831", "A004832", "A004833", "A004842", "A004843", "A004844", "A004845", "A004857", "A004869", "possible"]
   formalized:
     state: "yes"
     last_update: "2026-03-15"
@@ -5272,7 +5272,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["A004825", "A004832", "A004843", "possible"]
+  oeis: ["A004825", "A004832", "A004843", "A004854", "A004865", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problems [#323](https://www.erdosproblems.com/323) and [#325](https://www.erdosproblems.com/325) both concern

$$f_{k,m}(x) = \#\{\,n \le x : n \text{ is a sum of } m \text{ nonnegative } k\text{th powers}\,\},$$

\#323 asking about $f_{k,k}$ and about $f_{k,m}$ for $m < k$, and \#325 about $f_{k,3}$.

The **member sets** of this family turn out to be a complete, systematic block already in the OEIS: **A004825–A004869**. I checked 20 cells $(k,m)$ with $3 \le k \le 7$, $2 \le m \le k$, and **every one is present and matches exactly over its full stored data**.

### What this PR changes

**#325** already listed A004825, A004832 and A004843 (the $k=3,4,5$ cases of $m=3$). This adds the two remaining computed cases, so the $m = 3$ row is complete for $k \le 7$:

| k | A-number | `name` field, quoted verbatim | status |
|---|---|---|---|
| 3 | [A004825](https://oeis.org/A004825) | Numbers that are the sum of at most 3 positive cubes. | already listed |
| 4 | [A004832](https://oeis.org/A004832) | Numbers that are the sum of at most 3 nonzero 4th powers. | already listed |
| 5 | [A004843](https://oeis.org/A004843) | Numbers that are the sum of at most 3 positive 5th powers. | already listed |
| 6 | [A004854](https://oeis.org/A004854) | Numbers that are the sum of at most 3 nonzero 6th powers. | **new** |
| 7 | [A004865](https://oeis.org/A004865) | Numbers that are the sum of at most 3 positive 7th powers. | **new** |

**#323** had no A-numbers. It asks two questions, so this adds two groups. The diagonal $m = k$, for its first question:

| (k,m) | A-number | `name` field, quoted verbatim |
|---|---|---|
| (3,3) | [A004825](https://oeis.org/A004825) | Numbers that are the sum of at most 3 positive cubes. |
| (4,4) | [A004833](https://oeis.org/A004833) | Numbers that are the sum of at most 4 nonzero 4th powers. |
| (5,5) | [A004845](https://oeis.org/A004845) | Numbers that are the sum of at most 5 positive 5th powers. |
| (6,6) | [A004857](https://oeis.org/A004857) | Numbers that are the sum of at most 6 nonzero 6th powers. |
| (7,7) | [A004869](https://oeis.org/A004869) | Numbers that are the sum of at most 7 positive 7th powers. |

and the $m < k$ cases at $k = 4, 5$, for its second question:

| (k,m) | A-number | `name` field, quoted verbatim |
|---|---|---|
| (4,2) | [A004831](https://oeis.org/A004831) | Numbers that are the sum of at most 2 nonzero 4th powers. |
| (4,3) | [A004832](https://oeis.org/A004832) | Numbers that are the sum of at most 3 nonzero 4th powers. |
| (5,2) | [A004842](https://oeis.org/A004842) | Numbers that are the sum of at most 2 positive 5th powers. |
| (5,3) | [A004843](https://oeis.org/A004843) | Numbers that are the sum of at most 3 positive 5th powers. |
| (5,4) | [A004844](https://oeis.org/A004844) | Numbers that are the sum of at most 4 positive 5th powers. |

The $k = 6, 7$ sub-diagonal cells (A004853, A004855, A004856, A004864, A004866, A004867, A004868) were verified too and are omitted from the field only to keep it readable; happy to add them if you'd prefer completeness over brevity.

### On the wording difference — please check this rather than take it on trust

The problem says *"the sum of $m$ nonnegative $k$th powers"*; the OEIS names say *"the sum of **at most** $m$ **positive** $k$th powers"*. These describe the same set, since a sum of at most $m$ positive $k$th powers is a sum of exactly $m$ nonnegative ones after padding with zeros, and conversely.

This is not just an argument — it is visible in the data. Every one of these entries **begins with 0**, which is the empty sum, i.e. the all-zeros representation. My computed sets agree with the stored data **only** when 0 is included; excluding it makes all 20 fail. So the OEIS convention here matches the problem's "nonnegative" phrasing exactly.

(A004999 for $(k,m) = (3,2)$ is phrased differently again — *"Sums of two nonnegative cubes"* — and also matches. Not proposed for either field, since $m = 2 < 3$ falls outside both problems' stated ranges, but recorded here for completeness.)

### Why `"possible"` is retained on both

The natural object in the problem statements is the **counting function** $f_{k,m}(x)$ itself, and that is *not* in the OEIS — I searched by data and by name and found nothing. What is in the OEIS is the member set, which is essentially its inverse. Under the CONTRIBUTING rule of thumb ("a researcher interested in the Erdős problem would plausibly be interested in at least some of the information contained in the OEIS sequence page, or vice versa") the sets clearly qualify, but the counting functions remain uncomputed and unlisted, so further sequences could still be added. `"possible"` therefore stays on both entries.

For reference, the counting functions begin:

```
f_{3,3}(x), x=1..24:  1,2,3,3,3,3,3,4,5,6,6,6,6,6,6,7,8,8,8,8,8,8,8,9
f_{4,4}(x), x=1..24:  1,2,3,4,4,4,4,4,4,4,4,4,4,4,4,5,6,7,8,8,8,8,8,8
f_{5,5}(x), x=1..24:  1,2,3,4,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
```

and at powers of ten:

| (k,m) | f(10) | f(10²) | f(10³) | f(10⁴) | f(10⁵) |
|---|---|---|---|---|---|
| (3,3) | 6 | 28 | 173 | 1352 | 11662 |
| (4,3) | 3 | 14 | 48 | 194 | 949 |
| (5,3) | 3 | 9 | 19 | 70 | 208 |
| (4,4) | 4 | 21 | 96 | 540 | 4015 |
| (5,5) | 5 | 17 | 53 | 300 | 1619 |

A caution to whoever picks these up: searching OEIS for a counting function like $f_{5,3}$ returns confident-looking false matches (A316827, A158799, …) purely because its prefix is a long run of a constant. That is the hazard described in #356; the prefixes here are not discriminating and should not be trusted.

### Verification

Every set was computed **two independent ways**:

- **(A)** an $m$-fold recursion over the list of $k$th powers, marking each representable value directly;
- **(B)** iterated set convolution — start from $\{0\}$ and add the $k$th powers $m$ times over a boolean array.

The two share no code path beyond the list of $k$th powers, and agree over $0..20000$ for every $(k,m)$ tested. Each set was then compared to the live OEIS `data` field **term by term over the full stored range**, not just a prefix: 36–70 terms per entry, 20 entries, all exact. (The sweep was run twice, in separate processes, with identical results.)

Code is stdlib-only and included in a comment below so it can be read and re-run.

### AI disclosure

Prepared with AI assistance (GitHub Copilot CLI). Per CONTRIBUTING, no sequence here has been or will be submitted to the OEIS — every A-number cited already exists. No values were taken from a model: all figures come from code that was written, inspected and executed locally, computed by two separate algorithms, and checked against the live OEIS data.
