### PR TITLE
fix: flag problem 265 as ambiguous statement

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4301,6 +4301,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
+  comments: "ambiguous statement"
   tags: ["irrationality"]
 
 - number: "266"


### PR DESCRIPTION
## Summary
- Mark [problem 265](https://www.erdosproblems.com/265) with `comments: "ambiguous statement"`.
- The literal statement allows `a_1 = 1`, which makes \(\sum 1/(a_n-1)\) undefined; the intended reading is presumably \(a_1 \ge 2\) (see #359).
- Matches the CONTRIBUTING.md guidance for wording that is easily pathological or mismatched with the intended context.

## Test plan
- [ ] Confirm problem 265 in `data/problems.yaml` has `comments: "ambiguous statement"`
- [ ] `python scripts/validate.py` passes
- [ ] After merge, README ambiguous-statement count increases from 7 to 8

Closes #359

Made with [Cursor](https://cursor.com)