### PR TITLE
Erdős 608: record Lean formalization of the disproof

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -9866,7 +9866,9 @@
     state: "disproved"
     last_update: "2025-10-25"
   formal_status:
-    state: "unformalized"
+    state: "Lean"
+    last_update: "2026-07-29"
+    url: "https://github.com/primateria/erdos608"
   status:
     state: "disproved"
     last_update: "2025-10-25"


### PR DESCRIPTION
Sets `formal_status` of problem 608 to `Lean`, linking https://github.com/primateria/erdos608 — a Lean 4 / mathlib formalization of the disproof (statement, witness construction, and both negation theorems; zero `sorry`s; axioms exactly `[propext, Classical.choice, Quot.sound]`; CI re-runs the build and axiom audit on every push; independently rebuilt in a clean-room environment).

**Methodology** (per the invitation in CONTRIBUTING to describe it here): the witness is a rational specialization of the Füredi–Maleki construction as described by Grzesik–Hu–Volec (arXiv:1605.09055) — for n = 28m, a path-blowup A–B–C–D with D a clique and parts 4m/7m/7m/10m, giving an explicit uniform gap ε = 47/7056 below 2/9 (`strong_disproof`). The formalized `Conjecture` is the intended asymptotic reading (∃ n₀, ∀ n ≥ n₀, …); the repo separately proves the literal ∀n sentence degenerately false at K₃, and the asymptotic form is the logically weaker one, so its refutation covers both readings. Scope: the disproof only — not the sharp (2+√2)/16 constant of Grzesik–Hu–Volec.

**Disclosure:** the Lean proofs were written by AI agents (Anthropic's Claude) from a human-approved frozen statement, with blinded round-trip statement audits before proving; full methodology in the repo README. Scrutiny of statement fidelity (`Erdos608/Statement.lean`, ~50 lines) is particularly welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)