### PR TITLE
data: fix one impossible and 15 non-ISO date literals in problems.yaml

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -1108,12 +1108,12 @@
   prize: "no"
   informal_status:
     state: "proved"
-    last_update: "2025-12-2"
+    last_update: "2025-12-02"
   formal_status:
     state: "unformalized"
   status:
     state: "proved"
-    last_update: "2025-12-2"
+    last_update: "2025-12-02"
   oeis: ["A262153"]
   formalized:
     state: "yes"
@@ -3316,13 +3316,13 @@
   prize: "no"
   informal_status:
     state: "disproved"
-    last_update: "2026-1-10"
+    last_update: "2026-01-10"
   formal_status:
     state: "Lean"
-    last_update: "2026-1-10"
+    last_update: "2026-01-10"
   status:
     state: "disproved (Lean)"
-    last_update: "2026-1-10"
+    last_update: "2026-01-10"
   oeis: ["possible"]
   formalized:
     state: "no"
@@ -4017,12 +4017,12 @@
   prize: "no"
   informal_status:
     state: "proved"
-    last_update: "2025-12-2"
+    last_update: "2025-12-02"
   formal_status:
     state: "unformalized"
   status:
     state: "proved"
-    last_update: "2025-12-2"
+    last_update: "2025-12-02"
   oeis: ["N/A"]
   formalized:
     state: "yes"
@@ -4650,12 +4650,12 @@
   prize: "no"
   informal_status:
     state: "falsifiable"
-    last_update: "2025-12-5"
+    last_update: "2025-12-05"
   formal_status:
     state: "unformalized"
   status:
     state: "falsifiable"
-    last_update: "2025-12-5"
+    last_update: "2025-12-05"
   oeis: ["N/A"]
   formalized:
     state: "yes"
@@ -8200,13 +8200,13 @@
   prize: "no"
   informal_status:
     state: "disproved"
-    last_update: "2026-02-32"
+    last_update: "2026-02-02"
   formal_status:
     state: "Lean"
-    last_update: "2026-02-32"
+    last_update: "2026-02-02"
   status:
     state: "disproved (Lean)"
-    last_update: "2026-02-32"
+    last_update: "2026-02-02"
   oeis: ["possible"]
   formalized:
     state: "yes"
@@ -9945,13 +9945,13 @@
   prize: "no"
   informal_status:
     state: "disproved"
-    last_update: "2025-11-4"
+    last_update: "2025-11-04"
   formal_status:
     state: "Lean"
-    last_update: "2025-11-4"
+    last_update: "2025-11-04"
   status:
     state: "disproved (Lean)"
-    last_update: "2025-11-4"
+    last_update: "2025-11-04"
   oeis: ["N/A"]
   formalized:
     state: "yes"
@@ -16768,13 +16768,13 @@
   prize: "no"
   informal_status:
     state: "disproved"
-    last_update: "2025-12-4"
+    last_update: "2025-12-04"
   formal_status:
     state: "Lean"
-    last_update: "2025-12-4"
+    last_update: "2025-12-04"
   status:
     state: "disproved (Lean)"
-    last_update: "2025-12-4"
+    last_update: "2025-12-04"
   formalized:
     state: "no"
     last_update: "2025-09-10"


### PR DESCRIPTION
## What

Every `last_update` literal in `data/problems.yaml` now parses as a date. Two distinct
defects, **18 occurrences**, 18 changed lines, no other content touched.

### 1. An impossible date on #505 — 3 occurrences

```yaml
- number: "505"
  informal_status:
    last_update: "2026-02-32"   # and again under formal_status, and under status
```

February has no 32nd day, so no date library can read it. `datetime.date.fromisoformat`
raises `ValueError: day is out of range for month`; PyYAML leaves it as a bare `str`
while every other entry becomes a `datetime.date`, so the type of the field silently
varies across the file.

The value was introduced in 6e4745f *"Update problem 505 status and last update date"*,
authored **2026-02-02**, in the same hunk that set `state: "disproved (Lean)"`. That is
the date used here. If the intended date was something else, say so and I'll amend — the
point of the PR is that the current value cannot be right.

### 2. Non-zero-padded literals — 15 occurrences

| problem | value | occurrences |
|---|---|---|
| #69 | `2025-12-2` | 2 |
| #205 | `2026-1-10` | 3 |
| #248 | `2025-12-2` | 2 |
| #287 | `2025-12-5` | 2 |
| #613 | `2025-11-4` | 3 |
| #1034 | `2025-12-4` | 3 |

Unambiguous to a human, but not valid ISO 8601, and `datetime.date.fromisoformat`
rejects all fifteen. Zero-padded here.

## Verification

Counted by occurrence throughout — 3 + 15 = **18**, matching the 18 changed lines.

| | before | after |
|---|---|---|
| `last_update` literals | 3857 | 3857 |
| rejected by `date.fromisoformat` | **18** (6 distinct values, 6 problems) | **0** |
| `yaml.safe_load` | 1217 problems | 1217 problems |

`git diff` is exactly the 18 date lines and nothing else.

## How this was found

I was cross-referencing the site's forum index against the export and my parser crashed
on #505. So this is a by-product rather than an audit — which means I'd suggest a cheap
CI guard is worth more than the fix: asserting that every `last_update` satisfies
`datetime.date.fromisoformat` would have caught both classes at the commit that
introduced them, and costs milliseconds. Happy to add that in a follow-up if you want it.

---

*Disclosure: found and prepared with AI assistance (GitHub Copilot CLI). The defect and
the fix are both mechanically checkable from the diff, and the counts above were produced
by a script run against the file before and after.*

*Edited shortly after opening to fix an arithmetic slip in this description: I first
wrote "16 unparseable", having collapsed #505's three occurrences into one. The count is
18 occurrences of 6 distinct bad values, which is what the 18-line diff reflects. The
diff itself never changed.*
