### PR TITLE
data: note updated search bounds for #398 and #850

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -6462,7 +6462,7 @@
   formalized:
     state: "yes"
     last_update: "2025-09-01"
-  comments: "Brocard-Ramanujan conjecture"
+  comments: "Brocard-Ramanujan conjecture; no solutions with 7 < n <= 10^15 (Epstein–Glickman 2020), improving Berndt–Galway's 10^9 bound"
   tags: ["number theory", "factorials"]
 
 - number: "399"
@@ -13800,7 +13800,7 @@
   formalized:
     state: "yes"
     last_update: "2025-11-25"
-  comments: "Erdős-Woods conjecture"
+  comments: "Erdős-Woods conjecture; Hercher (arXiv:2506.01099) classifies all Benelux pairs with y < 1.4e12"
   tags: ["number theory", "primes"]
 
 - number: "851"


### PR DESCRIPTION
## Summary
- #398 (Brocard–Ramanujan): record Epstein–Glickman's search to \(10^{15}\) (issue #355), improving the often-quoted \(10^9\) bound.
- #850 (Erdős–Woods / Benelux pairs): note Hercher's classification below \(1.4\times 10^{12}\) (issue #371).

## Test plan
- [x] `python scripts/validate.py`
- [ ] Confirm comments render on the interactive table


Made with [Cursor](https://cursor.com)