### PR TITLE
data: mark problem 265 as ambiguous statement

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4310,6 +4310,7 @@
     state: "no"
     last_update: "2025-08-31"
   tags: ["irrationality"]
+  comments: "ambiguous statement"
 
 - number: "266"
   prize: "no"


### PR DESCRIPTION
## Summary
- Add `comments: "ambiguous statement"` for problem 265 per #359 (literal `a_1 ≥ 1` makes `∑ 1/(a_n-1)` undefined).

## Test plan
- [ ] YAML validates / table regenerates on merge
