### PR TITLE
Problem 993: add OEIS A000055 (free trees); retain possible flag

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -16123,7 +16123,7 @@
   formalized:
     state: "no"
     last_update: "2025-09-07"
-  oeis: ["possible"]
+  oeis: ["A000055", "possible"]
   tags: ["graph theory"]
 
 - number: "994"


### PR DESCRIPTION
Problem 993 (the 1987 Alavi-Malde-Schwenk-Erdős conjecture that the independence polynomial of every tree is unimodal) quantifies over free trees on n vertices, which are enumerated by [A000055](https://oeis.org/A000055) (number of trees with n unlabeled nodes). This is the sequence that every exhaustive verification of the conjecture walks through, so it seems the natural first OEIS link for this problem.

**Verification of the association** (per the CONTRIBUTING guidance on computing values): the conjecture has been exhaustively verified for all free trees on up to 32 vertices, and the per-order tree counts produced by these runs match A000055 term for term at every order — including a(32) = 109,972,410,221. Two independent implementations agree: [BrettRey/erdos-problem-993](https://github.com/BrettRey/erdos-problem-993) (n ≤ 29; see also arXiv:2604.18824) and [Tyorden/erdos-993-trees-n31](https://github.com/Tyorden/erdos-993-trees-n31) (independent reproduction of n ≤ 29 and extension to n ≤ 32, gentreeg + exact integer subtree DP), with identical counts on every common order.

The `possible` flag is retained: sequences derived from the independence polynomials themselves (e.g., coefficient statistics for notable tree families) could be linked in the future.

**AI disclosure** (per the CONTRIBUTING policy): my verification pipeline was written and run with Claude (Anthropic) assistance; its outputs are independently validated by the exact term-for-term match with A000055's published values and by agreement with the independent implementation above. No new sequence is being submitted to the OEIS here — this PR only links an existing, long-established sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)