### PR TITLE
Fix stale CSV header missing 'open' column in statistics_history.csv

### DIFF
--- a/data/statistics_history.csv
+++ b/data/statistics_history.csv
@@ -1,4 +1,4 @@
-commit,date,total_problems,lean_formalized,oeis_linked,total_solved,proved,disproved,solved,lean_solved
+commit,date,total_problems,lean_formalized,oeis_linked,total_solved,proved,disproved,solved,lean_solved,open
 cee85ee5b85bb8ccdbb51647ef3ab7d68a799668,2025-08-31 09:59:02 -0700,2,0,1,1,0,0,1,0
 c7623a59c530a573194fe00c82bded702faed2e0,2025-08-31 10:08:27 -0700,3,3,1,1,0,0,1,0
 3a01dfb81f0c29e6b8e5ed4b90b828fc9d485915,2025-08-31 10:26:37 -0700,200,3,1,1,0,0,1,0

--- a/scripts/plot_statistics_history.py
+++ b/scripts/plot_statistics_history.py
@@ -18,6 +18,19 @@ OUTPUT_DARK = ROOT / "data" / "statistics_history_dark.svg"
 FIELDNAMES = ["commit", "date", "total_problems", "lean_formalized", 
               "oeis_linked", "total_solved", "proved", "disproved", "solved", "lean_solved", "open"]
 
+def _as_int(value, default=0):
+    """Read a CSV cell that may be missing or blank.
+
+    ``csv.DictReader`` creates a key for every column in the header and fills it
+    with ``None`` on a short row, so ``row.get(name, default)`` never falls back
+    for a column the header declares.  Rows written before a column existed are
+    exactly that case.
+    """
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
 def get_current_commit():
     try:
         return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
@@ -35,7 +48,9 @@ def update_history(stats: dict) -> bool:
         with CSV_FILE.open("r", encoding="utf-8") as f:
             rows = list(csv.DictReader(f))
             if rows:
-                last_stats = {k: int(v) for k, v in rows[-1].items() if k in stats}
+                last_stats = {
+                    k: _as_int(v) for k, v in rows[-1].items() if k in stats
+                }
 
     # Compare (ignoring date/commit)
     if last_stats == stats:
@@ -125,13 +140,15 @@ def generate_charts():
     with CSV_FILE.open("r", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
+            total = _as_int(row.get("total_problems"))
+            solved = _as_int(row.get("total_solved"))
             data_points.append({
                 'date': datetime.strptime(row["date"], "%Y-%m-%d %H:%M:%S %z"),
-                'lean': int(row["lean_formalized"]),
-                'oeis': int(row["oeis_linked"]),
-                'solve': int(row["total_solved"]),
-                'lean_solved': int(row.get("lean_solved", 0)),
-                'open': int(row.get("open", int(row["total_problems"]) - int(row["total_solved"])))
+                'lean': _as_int(row.get("lean_formalized")),
+                'oeis': _as_int(row.get("oeis_linked")),
+                'solve': solved,
+                'lean_solved': _as_int(row.get("lean_solved")),
+                'open': _as_int(row.get("open"), total - solved)
             })
 
     if not data_points:


### PR DESCRIPTION
The `open` field was added to the row schema in commit 06fdb21 (scripts/plot_statistics_history.py FIELDNAMES) but the CSV header on line 1 of data/statistics_history.csv was never updated, since the header is only written by `update_history()` when the file doesn't yet exist. Every row appended since 2025-12-12 has 11 values while the header names only 10 columns.

Verified with `csv.DictReader` (what the repo's own scripts use to read this file): the 11th value on each affected row lands under the `None` restkey instead of `open`, so `row.get("open", ...)` in `generate_charts()` never finds the recorded value and silently falls back to a computed default. This happens to match numerically right now (default = total_problems - total_solved), which is why it wasn't noticed, but the CSV is malformed for any other consumer (pandas, spreadsheets, etc.) and the real recorded 'open' values are being discarded on every read.

Fix: add `open` to the header row so it matches the 11 columns actually written. Confirmed with DictReader before/after that the 'open' key now parses correctly for all post-06fdb21 rows, and that older rows (pre-'open' schema) correctly get `None` for the missing field. Ran `python scripts/validate.py` — passes.