### PR TITLE
Catch a hand-edited status even when the primitives also moved

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -117,8 +117,7 @@ for row in data:
 # scripts/derive_status.py on every push to main, so a stale value on a branch
 # is harmless.  What is *not* harmless is a contributor editing `status`
 # directly: that edit would be silently reverted.  We can tell the two apart
-# when the base revision is available, by checking whether `status` moved while
-# both primitives stayed put.
+# when the base revision is available, by checking whether `status` itself moved.
 base_rows = {}
 if args.base:
     base_path = Path(args.base)
@@ -143,11 +142,14 @@ for row in data:
 
     number = row.get("number")
     base_row = base_rows.get(number)
+    # We only get here when `status` disagrees with the derived value, so the
+    # question is simply whether this PR touched `status`.  If it did, the edit
+    # is a hand-edit that regeneration would silently throw away - no matter
+    # whether the primitives moved in the same PR.  If it did not, `status` is
+    # merely stale on the branch, which is harmless.
     hand_edited = (
         base_row is not None
         and dict(base_row.get("status") or {}) != current
-        and base_row.get("informal_status") == row.get("informal_status")
-        and base_row.get("formal_status") == row.get("formal_status")
     )
 
     if hand_edited:


### PR DESCRIPTION
`scripts/validate.py` explains that a stale `status` on a branch is harmless, but a contributor editing `status` directly is not, because regeneration silently reverts it. The check only fired when `status` moved **and** both `informal_status` and `formal_status` stayed put, so it misses the case where a PR edits a primitive and hand-edits `status` in the same change.

That is the likely shape of the mistake in practice: someone updates `informal_status` and helpfully "fixes up" `status` to match what they think it should be. If their value disagrees with the derived one, it passes validation and is thrown away on merge.

Reproduced against a one-problem base file (`informal_status: open`, `status: open`):

| case | branch content | before | after |
| --- | --- | --- | --- |
| A | `status` hand-edited, primitives untouched | ❌ error | ❌ error |
| **B** | `informal_status` → `disproved`, `status` hand-edited to `proved` | **✅ Validation OK** | ❌ error |
| C | `informal_status` → `disproved`, `status` left stale | notice, exit 0 | notice, exit 0 |
| D | `informal_status` → `disproved`, `status` correctly updated | silent, exit 0 | silent, exit 0 |

Case B is the gap; C and D confirm the stale-but-untouched path and the correct path are unchanged, so this does not start rejecting ordinary edits.

By the time control reaches this branch `status` already disagrees with the derived value, so the only remaining question is whether the PR touched `status` at all. Dropping the two primitive-equality conditions is what expresses that.

Also checked for false positives on the real file: `validate.py --base` over the current `data/problems.yaml` (1217 problems) against `main~5` and against `main` itself both report `✅ Validation OK`.