### PR TITLE
Keep tag counts out of their own filter

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -303,9 +303,14 @@ function updateTable() {
     // Update tag and dropdown displays with filtered counts
     const nonTagFiltersActive = hasNonTagFilters();
 
-    // Update tag display (excludes tag filters from count calculation)
+    // Update tag display (excludes tag filters from count calculation, so a
+    // selected tag does not zero out the count of every other tag)
     if (nonTagFiltersActive) {
-        window._filteredTagCounts = extractTagCounts(filteredProblems);
+        const withoutTagFilters = applyFilters(
+            searchProblems(allProblems, searchQuery),
+            { ...filters, tags: [] }
+        );
+        window._filteredTagCounts = extractTagCounts(withoutTagFilters);
         window._hasActiveFilters = true;
     } else {
         window._filteredTagCounts = null;


### PR DESCRIPTION
`updateTable` derives the per-tag counts from `filteredProblems`, which already has the tag filter applied. So as soon as you tick one tag, every other tag's count collapses to (nearly) zero and the tag list demotes them to the inactive tier — the opposite of what those counts are for, which is deciding which tag to add next. The comment directly above the block already says the counts exclude tag filters; the code doesn't.

Counting over the problems that match the search and the dropdown filters, but not the tag selection, fixes it.

With `status=open` and "number theory" selected, over today's `data/problems.yaml`:

```
graph theory:   1  ->  122
combinatorics:  0  ->   19
geometry:       1  ->   55
tags shown as active: 24 -> 38 (of 38)
```

(measured by running `applyFilters` + `extractTagCounts` from `docs/` under node, with and without the tag selection).