### PR TITLE
Refuse to rewrite problems.yaml from a partial listing

### DIFF
--- a/scripts/update_formalization_status.py
+++ b/scripts/update_formalization_status.py
@@ -29,6 +29,17 @@ def fetch_formalized_problem_numbers():
         print(f"Error fetching data from GitHub API: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # A partial listing is worse than no listing here: every problem missing from
+    # it gets rewritten to formalized "no", and the workflow commits that.
+    if data.get("truncated"):
+        print(
+            "Error: the GitHub tree listing came back truncated, so it does not "
+            "contain every formalization.  Refusing to rewrite problems.yaml from "
+            "a partial listing.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     formalized_numbers = set()
     for item in data.get("tree", []):
         path = item.get("path", "")
@@ -37,7 +48,16 @@ def fetch_formalized_problem_numbers():
             problem_number = Path(path).stem
             if problem_number.isdigit():
                 formalized_numbers.add(problem_number)
-    
+
+    if not formalized_numbers:
+        print(
+            f"Error: no files under {FILE_PREFIX} in the listing.  Either the "
+            "directory moved or the response was not the tree we asked for; "
+            "either way, marking every problem unformalized would be wrong.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     print(f"Found {len(formalized_numbers)} formalized problem files: {formalized_numbers}")
     return formalized_numbers
 


### PR DESCRIPTION
`update_formalization_status.py` treats whatever comes back from the GitHub tree API as the complete set of formalizations, and then rewrites every problem outside that set to `formalized: no`. The workflow commits and pushes `data/problems.yaml` straight after, so a single degraded response silently undoes hundreds of entries with no one in the loop.

Two guards, both about responses that are *successful* but not complete:

- stop if the API reports the listing as `truncated` (it does that once a tree gets large — the repo is at 1504 entries today, so this is headroom, not a current failure);
- stop if the listing contains no files under `FormalConjectures/ErdosProblems/` at all, which is what a moved directory or a wrong-tree response looks like — and is exactly the case where the script would mark all 1217 problems unformalized.

Measured with today's real listing truncated to its first 200 entries: the current script sees 99 of the 609 formalized problems and would flip the other 510 to `no`. With this change it exits 1 and writes nothing. The untruncated listing still yields all 609, so the normal path is unaffected.