### PR TITLE
Compare OEIS cons digits with truncation, not rounding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,12 @@ appropriate [Erdős problem web page](https://www.erdosproblems.com) and see if 
 Note that in some cases, the integer sequences associated to a problem may be somewhat implicit.  For instance:
 
 - The problem may involve a specific real number, such as [Vardi's constant](https://oeis.org/A076393). In that case, the relevant integer sequence would be the decimal expansion of the sequence.
+  OEIS `cons` (decimal expansion) entries store digits **truncated**, not rounded.
+  Printing with `mpmath.nstr`, f-strings, or `format` usually rounds, which can
+  flip the last digit and produce a silent false negative against a correct
+  match. Use [`scripts/oeis_cons_compare.py`](scripts/oeis_cons_compare.py) to
+  truncate and to flag when rounding alone would have rejected the match.
+
 - The problem may involve an integer function of two variables rather than one.  In such cases, there may be interesting sequences to extract by specializing one of the variables to a notable value.  For instance, if the problem involves a function $r_k(N)$ of two parameters $k,N$, it may be of interest to use specific choices of one parameter, e.g., $k=1,2,3$, as examples of sequences associated to the problem.  In some cases, listing the entire two-variable function as a [table](https://oeis.org/wiki/Clear-cut_examples_of_keywords#tabl).
 - The problem may ask to upper or lower bound the "score" of an object $A$ that is defined on some space of "size" $n$ (e.g., $A$ could range over subsets of $\{1,\dots,n\}$ obeying some additional properties), where the "score" could refer to the cardinality of $A$, or some other more complicated metric.  In that case, the natural sequence to consider is the maximal or minimal "score" of such an object, as a function of $n$.
 - In a small number of cases, the natural sequence to consider is a sequence of rational numbers rather than integers.  In such cases, one can take the numerator and denominator of these numbers (in reduced form) as two separate integer sequences and see if they are already in the OEIS.  Or one can try to renormalize the sequence to take integer values rather than rational ones.

--- a/scripts/oeis_cons_compare.py
+++ b/scripts/oeis_cons_compare.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Compare a rational against an OEIS `cons` (decimal expansion) entry.
+
+OEIS keyword:cons sequences store digits *truncated*, not rounded. Common
+printers (mpmath.nstr, f-strings, format) round, so a correct constant can
+disagree with OEIS on the last digit whenever the next digit is >= 5.
+
+This helper truncates via Decimal and reports whether a mismatch is that
+rounding artefact or a genuine non-match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from decimal import Decimal, getcontext, ROUND_DOWN, ROUND_HALF_UP
+from fractions import Fraction
+
+
+def digits_truncated(value: Fraction, n: int) -> str:
+    """Return the first n significant digits of value, truncated."""
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if value <= 0:
+        raise ValueError("value must be positive")
+
+    getcontext().prec = n + 20
+    d = Decimal(value.numerator) / Decimal(value.denominator)
+    # Scientific form so we always get significant digits, not a fixed scale.
+    normalized = d.normalize()
+    # Digits without exponent: use to_integral / quantize on significand.
+    sign, digits, exp = normalized.as_tuple()
+    digit_str = "".join(str(x) for x in digits)
+    if len(digit_str) < n:
+        # Need more fractional digits from a higher precision render.
+        getcontext().prec = max(n + 20, getcontext().prec)
+        d = Decimal(value.numerator) / Decimal(value.denominator)
+        # floor(d * 10^(n-1-floor(log10(d))))
+        from math import floor, log10
+
+        log = floor(log10(float(d)))
+        scale = Decimal(10) ** (n - 1 - log)
+        scaled = (d * scale).to_integral_value(rounding=ROUND_DOWN)
+        digit_str = format(int(scaled), "d")
+        if len(digit_str) > n:
+            digit_str = digit_str[:n]
+        elif len(digit_str) < n:
+            digit_str = digit_str.ljust(n, "0")
+    return digit_str[:n]
+
+
+def digits_rounded(value: Fraction, n: int) -> str:
+    """Return the first n significant digits of value, rounded half-up."""
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if value <= 0:
+        raise ValueError("value must be positive")
+    getcontext().prec = n + 20
+    d = Decimal(value.numerator) / Decimal(value.denominator)
+    from math import floor, log10
+
+    log = floor(log10(float(d)))
+    scale = Decimal(10) ** (n - 1 - log)
+    scaled = (d * scale).to_integral_value(rounding=ROUND_HALF_UP)
+    digit_str = format(int(scaled), "d")
+    if len(digit_str) > n:
+        # Rounding carried into an extra digit (e.g. 999... -> 1000...).
+        digit_str = digit_str[:n]
+    elif len(digit_str) < n:
+        digit_str = digit_str.ljust(n, "0")
+    return digit_str[:n]
+
+
+def compare_cons(value: Fraction, oeis_digits: str) -> dict:
+    """Compare value to an OEIS cons digit string.
+
+    Returns a dict with keys:
+      match: bool — truncated digits equal OEIS
+      truncated: str
+      rounded: str
+      rounding_false_negative: bool — rounded disagrees but truncated matches
+    """
+    oeis_digits = "".join(ch for ch in oeis_digits if ch.isdigit())
+    n = len(oeis_digits)
+    if n == 0:
+        raise ValueError("oeis_digits must contain at least one digit")
+    truncated = digits_truncated(value, n)
+    rounded = digits_rounded(value, n)
+    match = truncated == oeis_digits
+    return {
+        "match": match,
+        "truncated": truncated,
+        "rounded": rounded,
+        "oeis": oeis_digits,
+        # Truncated agrees with OEIS, but a rounded print would have disagreed.
+        "rounding_false_negative": match and rounded != oeis_digits,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("numerator", type=int, help="numerator of the exact Fraction")
+    parser.add_argument("denominator", type=int, help="denominator of the exact Fraction")
+    parser.add_argument("oeis_digits", help="digit string from the OEIS cons entry (punctuation ignored)")
+    args = parser.parse_args(argv)
+    result = compare_cons(Fraction(args.numerator, args.denominator), args.oeis_digits)
+    if result["rounding_false_negative"]:
+        print(
+            "TRUNCATION MATCH (rounding would have false-negatived): "
+            f"truncated={result['truncated']} rounded={result['rounded']} oeis={result['oeis']}",
+            file=sys.stderr,
+        )
+    elif result["match"]:
+        print(f"match: {result['truncated']}")
+    else:
+        print(
+            f"mismatch: truncated={result['truncated']} rounded={result['rounded']} oeis={result['oeis']}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_oeis_cons_compare.py
+++ b/tests/test_oeis_cons_compare.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from oeis_cons_compare import compare_cons, digits_rounded, digits_truncated
+
+
+def test_two_thirds_truncation_vs_rounding():
+    # Issue #357 minimal reproduction: 2/3 to 15 digits.
+    assert digits_truncated(Fraction(2, 3), 15) == "666666666666666"
+    assert digits_rounded(Fraction(2, 3), 15) == "666666666666667"
+
+
+def test_compare_detects_rounding_false_negative():
+    oeis = "666666666666666"
+    result = compare_cons(Fraction(2, 3), oeis)
+    assert result["match"] is True
+    assert result["rounding_false_negative"] is True
+    assert result["rounded"] == "666666666666667"
+
+
+def test_genuine_mismatch():
+    result = compare_cons(Fraction(1, 7), "666666666666666")
+    assert result["match"] is False
+    assert result["rounding_false_negative"] is False
+
+
+if __name__ == "__main__":
+    test_two_thirds_truncation_vs_rounding()
+    test_compare_detects_rounding_false_negative()
+    test_genuine_mismatch()
+    print("ok - oeis cons compare")


### PR DESCRIPTION
## Summary
- OEIS `cons` entries store truncated digits; rounded printers silently reject correct matches when the next digit is `>= 5`.
- Adds `scripts/oeis_cons_compare.py` to truncate via `Decimal` and flag rounding false-negatives.
- Points the OEIS linking notes at the helper.

Fixes #357.

## Test plan
- [x] `python3 tests/test_oeis_cons_compare.py`


