### PR TITLE
Link OEIS sequences for problems 694, 1162, 1181

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -11355,7 +11355,7 @@
   status:
     state: "solved (Lean)"
     last_update: "2026-05-06"
-  oeis: ["possible"]
+  oeis: ["A002181", "A006511", "A049283", "A057635", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"
@@ -18953,7 +18953,7 @@
   formalized:
     state: "no"
     last_update: "2026-01-23"
-  oeis: ["possible"]
+  oeis: ["A005432", "possible"]
   tags: ["group theory"]
 
 - number: "1163"
@@ -19258,7 +19258,7 @@
   formalized:
     state: "no"
     last_update: "2026-03-07"
-  oeis: ["possible"]
+  oeis: ["A053669", "A053670", "A053671", "A053672", "A053673", "A053674", "possible"]
   tags: ["number theory"]
 
 - number: "1182"


### PR DESCRIPTION
Following the [Linking with the OEIS](https://github.com/teorth/erdosproblems/blob/main/CONTRIBUTING.md#linking-with-the-oeis) guidance, three problems flagged `oeis: ["possible"]` where the associated sequence turned out to already be in the OEIS. For each one below: the OEIS definition is quoted so it can be checked against the problem statement, and the terms were computed here by two independently written programs before being compared with the published entry.

I have kept the `possible` flag on all three. Simply in each case the problem plausibly has further sequences attached (noted per problem).

> **AI disclosure.** This work was done with AI assistance. Nothing here has been or will be submitted to the OEIS. Following the CONTRIBUTING advice, every sequence was computed **twice by separately written programs using different algorithms**, and the two agree over the whole range checked; the ranges are stated below. No sequence values were taken from a language model; only from code that was read and run.

---

### [694] -- extremes of the totient preimage -> A002181, A006511, A049283, A057635

The problem defines $f_{\max}(n)$ as the largest $m$ with $\phi(m)=n$ and $f_{\min}(n)$ as the smallest such $m$, and studies $\max_{n\le x} f_{\max}(n)/f_{\min}(n)$ with $n$ restricted to the range of $\phi$.

Both functions are in the OEIS, under each of the two natural indexings:

| A-number | OEIS name | is |
|---|---|---|
| [A049283](https://oeis.org/A049283) | "a(n) is the smallest k such that phi(k) = n … or a(n) = 0 if no such k exists" | $f_{\min}(n)$ verbatim |
| [A057635](https://oeis.org/A057635) | "a(n) is the largest m such that phi(m) = n … or a(n) = 0 if no such m exists" | $f_{\max}(n)$ verbatim |
| [A002181](https://oeis.org/A002181) | "Least number k such that phi(k) = m, where m runs through the values (A002202) taken by phi" | $f_{\min}$ under exactly the restriction the problem imposes |
| [A006511](https://oeis.org/A006511) | "Largest inverse of totient function … a(n) is the largest x such that phi(x) = m, where m = A002202(n)" | $f_{\max}$ under the same restriction |

**Verification.** Computed $f_{\min},f_{\max}$ for $n=1\ldots60$ two ways: (a) a linear sieve of $\phi$ over $m\le 4n^2+10$ recording the first and last preimage of each value; (b) a per-$n$ scan of $m=1\ldots 2n^2$ using `sympy.totient`. The search range is exhaustive, since $\phi(m)\ge\sqrt{m/2}$ forces $m\le 2n^2$ whenever $\phi(m)=n$. The two agree, and match A049283 and A057635 term-for-term on $n=1\ldots60$; dropping the zeros gives the first 26 terms of A002181 and A006511 exactly.

Keeping `possible`: the Carmichael-conjecture half of the problem ("is there an $n$ with $f_{\max}(n)/f_{\min}(n)=1$") points at the multiplicity sequence [A014197](https://oeis.org/A014197), which I have not checked and have not added.

### [1162] -- number of subgroups of $S_n$ -> A005432

The problem asks for an asymptotic formula for $f(n)$, the number of subgroups of $S_n$.

[A005432](https://oeis.org/A005432): *"Number of permutation groups of degree n (or, number of distinct subgroups of symmetric group $S_n$, counting conjugates as distinct)."* That is $f(n)$, with offset 0.

**Verification.** Enumerated every subgroup of $S_n$ for $n\le6$ by closure from generating sets, with two implementations. One extending each known subgroup by every element of the group, one deduplicating candidate extensions by the coset $Hg$. Both give

```
n:     1  2  3   4    5     6
f(n):  1  2  6  30  156  1455
```

which is A005432 at indices 1..6 (the entry's `1, 1, 2, 6, 30, 156, 1455, …` starts at $n=0$).

Because $n=6$ rests on a single enumeration, here is an independent structural check of it, the subgroups of $S_6$ by order:

```
order:  1   2   3    4   5    6    8   9  10   12  16  18  20  24  36  48  60  72  120  360  720
count:  1  75  40  255  36  280  255  10  36  150  45  50  36  90  30  30  12  10   12    1    1
```

Each of these is checkable without re-running the enumeration: the Sylow counts are 45 (order 16), 10 (order 9) and 36 (order 5), consistent with $n_p\equiv1\pmod p$ and $n_p\mid[G:P]$; the 75 subgroups of order 2 are the $15+45+15$ involutions of cycle type $2,2^2,2^3$; the 40 of order 3 are the 80 elements of order 3 in pairs; the 36 of order 5 are the 144 5-cycles in fours; and the 12 subgroups of order 120 are the two conjugacy classes of $S_5$ in $S_6$ (point stabilisers and their images under the outer automorphism). The counts 1 (order 360, $A_6$) and 1 (order 720) are forced.

As corroboration rather than evidence: A005432's comment cites the same Pyber bound $c^{n^2(1+o(1))}\le a(n)\le d^{n^2(1+o(1))}$ that the problem page cites.

Keeping `possible`: the problem's second half ("is there a statistical theorem on their order?") is not captured by A005432.

### [1181] -- least prime missing from a block of consecutive integers -> A053669–A053674

The problem defines $q(n,k)$ as the least prime which does not divide $\prod_{1\le i\le k}(n+i)$, and asks about $k=\log n$. Following the CONTRIBUTING suggestion for two-variable functions, specialising $k$ gives a block of six existing entries:

| $k$ | A-number | OEIS name |
|---|---|---|
| 1 | [A053669](https://oeis.org/A053669) | "Smallest prime not dividing n" |
| 2 | [A053670](https://oeis.org/A053670) | "Least number coprime to n and n+1" |
| 3 | [A053671](https://oeis.org/A053671) | "Least number coprime to n, n+1 and n+2" |
| 4 | [A053672](https://oeis.org/A053672) | "Least number coprime to n, n+1, n+2 and n+3" |
| 5 | [A053673](https://oeis.org/A053673) | "Least number > 1 coprime to n, n+1, n+2, n+3 and n+4" |
| 6 | [A053674](https://oeis.org/A053674) | "Least number coprime to n, n+1, n+2, n+3, n+4 and n+5" |

Two remarks on why these are the same object as $q(n,k)$ and not simply close to it:

* "Least number ($>1$) coprime to $m,\dots,m+k-1$" and "least prime not dividing $m\cdots(m+k-1)$" are the same function, because the least integer $>1$ coprime to a given integer is always prime.
* The indexing differs by one: the OEIS entries are indexed by the **first** of the $k$ consecutive integers, whereas $q(n,k)$ is indexed by its predecessor. So $q(n,k)=\text{A05366}(8+k)(n+1)$. This is stated explicitly because it is the kind of off-by-one that would otherwise look like a mismatch.

**Verification.** Computed $q(n,k)$ two ways: (a) walking up the primes and testing divisibility of the product; (b) factoring the product with `sympy.factorint` and taking the least prime absent from the factor set. The two agree, and match each published entry over its full listed data under the shift above: $k=1,2$ to $n=100$, $k=3$ to $91$, $k=4$ to $84$, $k=5$ to $76$, $k=6$ to $71$.

Keeping `possible`: the problem is really about $k$ growing with $n$ (specifically $k=\log n$), which none of the fixed-$k$ specializations captures.
