### PR TITLE
Re-sync the tags field with erdosproblems.com

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -1393,7 +1393,7 @@
   formalized:
     state: "yes"
     last_update: "2025-11-21"
-  tags: ["graph theory"]
+  tags: ["graph theory", "ramsey theory"]
 
 - number: "86"
   prize: "$100"
@@ -2035,7 +2035,7 @@
   formalized:
     state: "yes"
     last_update: "2025-11-12"
-  tags: ["number theory", "base representations"]
+  tags: ["number theory", "base representations", "complete sequences"]
 
 - number: "125"
   prize: "no"
@@ -2248,7 +2248,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "138"
   prize: "$500"
@@ -2643,7 +2643,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["combinatorics", "ramsey theory", "discrepancy"]
+  tags: ["combinatorics", "ramsey theory", "discrepancy", "hypergraphs"]
 
 - number: "162"
   prize: "no"
@@ -3072,7 +3072,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["additive combinatorics", "ramsey theory"]
+  tags: ["additive combinatorics", "ramsey theory", "arithmetic progressions"]
 
 - number: "188"
   prize: "no"
@@ -3352,7 +3352,7 @@
   formalized:
     state: "yes"
     last_update: "2026-01-17"
-  tags: ["covering systems"]
+  tags: ["covering systems", "divisors"]
 
 - number: "205"
   prize: "no"
@@ -3516,7 +3516,7 @@
   formalized:
     state: "yes"
     last_update: "2026-08-03"
-  tags: ["geometry", "distances"]
+  tags: ["geometry", "distances", "ramsey theory"]
 
 - number: "215"
   prize: "no"
@@ -3994,7 +3994,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "irrationality"]
 
 - number: "244"
   prize: "no"
@@ -5323,7 +5323,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory", "powers"]
+  tags: ["number theory", "powers", "sidon sets"]
 
 - number: "325"
   prize: "no"
@@ -5404,7 +5404,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "sidon sets"]
 
 - number: "330"
   prize: "no"
@@ -5812,7 +5812,7 @@
   formalized:
     state: "yes"
     last_update: "2025-09-05"
-  tags: ["number theory"]
+  tags: ["number theory", "complete sequences"]
 
 - number: "355"
   prize: "no"
@@ -5978,7 +5978,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "365"
   prize: "no"
@@ -5994,7 +5994,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "366"
   prize: "no"
@@ -6011,7 +6011,7 @@
     state: "yes"
     last_update: "2025-08-31"
   comments: "ambiguous statement"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "367"
   prize: "no"
@@ -6027,7 +6027,7 @@
   formalized:
     state: "yes"
     last_update: "2026-08-20"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "368"
   prize: "no"
@@ -6157,7 +6157,7 @@
   formalized:
     state: "yes"
     last_update: "2026-01-18"
-  tags: ["number theory"]
+  tags: ["number theory", "primes"]
 
 - number: "376"
   prize: "no"
@@ -7826,7 +7826,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "sidon sets"]
 
 - number: "478"
   prize: "no"
@@ -8356,7 +8356,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["analysis"]
+  tags: ["analysis", "polynomials"]
 
 - number: "510"
   prize: "no"
@@ -8844,7 +8844,7 @@
   formalized:
     state: "yes"
     last_update: "2026-04-16"
-  tags: ["number theory"]
+  tags: ["number theory", "additive combinatorics"]
 
 - number: "540"
   prize: "no"
@@ -9374,7 +9374,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["graph theory", "turan number"]
+  tags: ["graph theory", "turan number", "cycles"]
 
 - number: "573"
   prize: "no"
@@ -10040,7 +10040,7 @@
   formalized:
     state: "yes"
     last_update: "2026-05-09"
-  tags: ["graph theory"]
+  tags: ["graph theory", "ramsey"]
 
 - number: "614"
   prize: "no"
@@ -10560,7 +10560,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory", "additive combinatorics", "ramsey theory"]
+  tags: ["number theory", "additive combinatorics", "ramsey theory", "arithmetic progressions"]
 
 - number: "646"
   prize: "no"
@@ -13481,7 +13481,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "divisors", "unit fractions"]
 
 - number: "826"
   prize: "no"
@@ -15266,7 +15266,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "936"
   prize: "no"
@@ -15282,7 +15282,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "937"
   prize: "no"
@@ -15299,7 +15299,7 @@
   formalized:
     state: "yes"
     last_update: "2026-06-24"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "938"
   prize: "no"
@@ -15315,7 +15315,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "939"
   prize: "no"
@@ -15331,7 +15331,7 @@
   formalized:
     state: "yes"
     last_update: "2025-09-01"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "940"
   prize: "no"
@@ -15347,7 +15347,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "941"
   prize: "no"
@@ -15363,7 +15363,7 @@
   formalized:
     state: "no"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "942"
   prize: "no"
@@ -15379,7 +15379,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "943"
   prize: "no"
@@ -15395,7 +15395,7 @@
   formalized:
     state: "yes"
     last_update: "2025-08-31"
-  tags: ["number theory"]
+  tags: ["number theory", "powerful"]
 
 - number: "944"
   prize: "no"
@@ -15916,7 +15916,7 @@
   formalized:
     state: "yes"
     last_update: "2025-12-20"
-  tags: ["number theory", "divisors"]
+  tags: ["number theory", "divisors", "polynomials"]
 
 - number: "976"
   prize: "no"
@@ -16451,7 +16451,7 @@
     state: "yes"
     last_update: "2026-08-05"
   oeis: ["N/A"]
-  tags: ["graph theory"]
+  tags: ["graph theory", "cycles"]
 
 - number: "1009"
   prize: "no"
@@ -16530,7 +16530,7 @@
     state: "no"
     last_update: "2025-09-10"
   oeis: ["A292528"]
-  tags: ["graph theory"]
+  tags: ["graph theory", "chromatic number"]
 
 - number: "1014"
   prize: "no"
@@ -16547,7 +16547,7 @@
     state: "yes"
     last_update: "2026-08-05"
   oeis: ["possible"]
-  tags: ["graph theory"]
+  tags: ["graph theory", "ramsey theory"]
 
 - number: "1015"
   prize: "no"
@@ -16955,7 +16955,7 @@
     state: "no"
     last_update: "2025-09-10"
   oeis: ["N/A"]
-  tags: ["analysis"]
+  tags: ["analysis", "polynomials"]
 
 - number: "1040"
   prize: "no"
@@ -16987,7 +16987,7 @@
     state: "yes"
     last_update: "2025-11-26"
   oeis: ["N/A"]
-  tags: ["analysis"]
+  tags: ["analysis", "polynomials"]
 
 - number: "1042"
   prize: "no"
@@ -17801,7 +17801,7 @@
     state: "no"
     last_update: "2025-09-28"
   oeis: ["N/A"]
-  tags: ["geometry", "chromatic number"]
+  tags: ["chromatic number", "graph theory"]
 
 - number: "1092"
   prize: "no"
@@ -17818,7 +17818,7 @@
     state: "yes"
     last_update: "2026-01-08"
   oeis: ["N/A"]
-  tags: ["geometry", "chromatic number"]
+  tags: ["chromatic number", "graph theory"]
 
 - number: "1093"
   prize: "no"
@@ -18518,7 +18518,7 @@
     last_update: "2026-01-13"
   oeis: ["A006370", "A008908"]
   comments: "Collatz conjecture"
-  tags: ["number theory"]
+  tags: ["number theory", "iterated functions"]
 
 - number: "1136"
   prize: "no"
@@ -19035,7 +19035,7 @@
     state: "yes"
     last_update: "2026-05-25"
   oeis: ["N/A"]
-  tags: ["set theory", "probability"]
+  tags: ["set theory", "ramsey theory"]
 
 - number: "1168"
   prize: "no"
@@ -19179,7 +19179,7 @@
     state: "yes"
     last_update: "2026-02-03"
   oeis: ["N/A"]
-  tags: ["set theory", "chromatic number"]
+  tags: ["set theory", "ramsey theory"]
 
 - number: "1177"
   prize: "no"
@@ -19485,7 +19485,7 @@
     state: "no"
     last_update: "2026-04-04"
   oeis: ["possible"]
-  tags: ["number theory"]
+  tags: ["number theory", "analysis"]
 
 - number: "1196"
   prize: "no"


### PR DESCRIPTION
`CONTRIBUTING.md` describes **tags** as "the tags associated to the problem from the erdosproblems.com database", and in [#26](https://github.com/teorth/erdosproblems/issues/26) the position was that "the tags on this site were copied from the tags on erdosproblems.com but are not synchronized going forward". They have drifted.

I compared the membership of all 42 tags against the site and found 48 assignments out of step: 44 problems missing a tag the site records, and 4 tags the site has since moved elsewhere. This PR brings them back in line. After it, the two vocabularies agree exactly, tag for tag and problem for problem, at 2020 assignments.

## The largest gap

`powerful`: erdosproblems.com lists 16 problems, `problems.yaml` has 2. The 14 missing are 137, 364, 365, 366, 367 and the block 935–943.

## The four removals

Each is half of a retag the site made, so the same entry gains the replacement in the same edit:

| problem | dropped | gained |
|---|---|---|
| 1091 | geometry | graph theory |
| 1092 | geometry | graph theory |
| 1167 | probability | ramsey theory |
| 1176 | chromatic number | ramsey theory |

`ramsey` was also unused here (distinct from `ramsey theory`) although the site lists problem 613 under it.

## Everything else

| tag | problems added |
|---|---|
| additive combinatorics | 539 |
| analysis | 1195 |
| arithmetic progressions | 187, 645 |
| chromatic number | 1013 |
| complete sequences | 124, 354 |
| cycles | 572, 1008 |
| divisors | 204, 825 |
| graph theory | 1091, 1092 |
| hypergraphs | 161 |
| irrationality | 243 |
| iterated functions | 1135 |
| polynomials | 509, 975, 1039, 1041 |
| powerful | 137, 364, 365, 366, 367, 935, 936, 937, 938, 939, 940, 941, 942, 943 |
| primes | 375 |
| ramsey | 613 |
| ramsey theory | 85, 214, 1014, 1167, 1176 |
| sidon sets | 324, 329, 477 |
| unit fractions | 825 |

## How I checked it

For each of the 42 tags I took the set of problems on `https://www.erdosproblems.com/tags/<tag>` from the `<div id="problem_id">` anchors, which excludes the cross-references in problem bodies. The sizes of those 42 sets match the "X solved out of Y" figures on `https://www.erdosproblems.com/tags` exactly, for every tag — that is the cross-check that the extraction is complete rather than a subset. I then spot-checked two entries on their own pages: `/943` is tagged "number theory, powerful" and `/1176` "set theory, ramsey theory", both as recorded here now.

New tags are appended to the existing list, which is the order the site itself uses on the entries I looked at. The file was edited through `ruamel` (a load/dump round trip on the unmodified file is byte-identical), so the rewrite matches what CI produces apart from the 44 changed lines.

Ran locally: `scripts/validate.py --base <main>/data/problems.yaml` passes, `scripts/derive_status.py --check` is up to date, and `scripts/generate_readme.py` confines its diff to the tag column of those 44 rows — so `README.md` is left out of this PR for CI to regenerate.

Happy to split this, or to drop the four removals if the site's retagging is not something you want mirrored.
