### PR TITLE
Match README AI Attempts labels to the interactive view/add rule

### DIFF
--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -40,8 +40,12 @@ def formalized_link(number:str, code: str) -> str:
     else:
         return code
 
-def ai_attempts_link(number: str) -> str:
-    return md_link("view", f"https://mehmetmars7.github.io/Erdosproblems-llm-hunter/problem.html?type=erdos&id={number}")
+AI_ELIGIBLE_STATES = {"open", "verifiable", "independent", "falsifiable"}
+
+def ai_attempts_link(number: str, informal_state: str) -> str:
+    # Match docs/utils.js: eligible states link as "view", otherwise "add".
+    label = "view" if informal_state.lower() in AI_ELIGIBLE_STATES else "add"
+    return md_link(label, f"https://mehmetmars7.github.io/Erdosproblems-llm-hunter/problem.html?type=erdos&id={number}")
 
 def filter_link(count: int, **params: str) -> str:
     """Create a link to the interactive table with one or more filters applied."""
@@ -248,7 +252,7 @@ def build_table(rows):
         rid = num_link(r["number"])
         prize = r.get("prize", "?")
         formalized = formalized_link(r["number"], r.get("formalized", {}).get("state", "?"))
-        ai_attempts = ai_attempts_link(r["number"])
+        ai_attempts = ai_attempts_link(r["number"], primitive_states(r)[0])
         comments = r.get("comments", "")
         lines.append(f"| {rid} | {prize} | {status} | {formalized} | {ai_attempts} | {oeis} | {tags} | {comments} |")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- README always linked AI Attempts as "view".
- Mirror `docs/utils.js`: "view" for open/verifiable/independent/falsifiable, otherwise "add".

## Test plan
- [x] Label helper matches JS eligibility set
- [ ] Regenerated README (optional follow-up) shows mixed view/add