### PR TITLE
Use "Lean" rather than "formalized" as `formal_status`

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -4,7 +4,8 @@
     state: "disproved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "disproved (formalized)"
     last_update: "2025-08-31"
@@ -1207,7 +1208,8 @@
     state: "disproved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "disproved (formalized)"
     last_update: "2025-08-31"
@@ -2060,7 +2062,8 @@
     state: "proved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "proved (formalized)"
     last_update: "2025-08-31"
@@ -8982,7 +8985,8 @@
     state: "proved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "proved (formalized)"
     last_update: "2025-08-31"
@@ -9126,7 +9130,8 @@
     state: "proved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "proved (formalized)"
     last_update: "2025-08-31"
@@ -9350,7 +9355,8 @@
     state: "proved"
     last_update: "2025-08-31"
   formal_status:
-    state: "formalized"
+    state: "Lean"
+    last_update: "2026-09-03"
   status:
     state: "proved (formalized)"
     last_update: "2025-08-31"


### PR DESCRIPTION
Problems 1, 74, 126, 548, 557 and 571 have `formal_status.state: "formalized"`, which is not one of the permitted schema values.