### PR TITLE
Problems 308, 634, 939, 942, 943, 1140, 1161: add existing OEIS sequences (7 one-line edits)

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -5060,7 +5060,7 @@
   status:
     state: "proved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A101877", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"
@@ -10384,7 +10384,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A005792", "possible"]
   formalized:
     state: "no"
     last_update: "2025-08-31"
@@ -15333,7 +15333,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A297867", "A036966", "possible"]
   formalized:
     state: "yes"
     last_update: "2025-09-01"
@@ -15381,7 +15381,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A119241", "A119242"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"
@@ -15397,7 +15397,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A085252", "A085253", "A085255"]
   formalized:
     state: "yes"
     last_update: "2025-08-31"
@@ -18605,7 +18605,7 @@
   formalized:
     state: "no"
     last_update: "2026-01-23"
-  oeis: ["possible"]
+  oeis: ["A240842", "possible"]
   tags: ["number theory"]
 
 - number: "1141"
@@ -18943,7 +18943,7 @@
   formalized:
     state: "no"
     last_update: "2026-01-23"
-  oeis: ["possible"]
+  oeis: ["A057731", "possible"]
   tags: ["group theory"]
 
 - number: "1162"


### PR DESCRIPTION
Seven `oeis` links for problems currently marked `possible`, each to a long-established OEIS
entry whose definition is the function or set the problem page defines (or its stated
restriction). Same format as #375. Every OEIS entry was fetched live on 2026-09-04; the
sequences below are all older entries with independent contributors, none submitted by me.

**Definition-exhausted (`possible` removed):**

- **#942** (h(n) = number of powerful numbers in [n^2,(n+1)^2)): [A119241](https://oeis.org/A119241)
  "Number of powerful numbers between consecutive squares n^2 and (n+1)^2" — exclusive of the
  endpoints, so h(n) = A119241(n) + 1 (n^2 itself is powerful). Also
  [A119242](https://oeis.org/A119242), the least k with exactly n powerful numbers between k^2
  and (k+1)^2 (Pettigrew's table; a(n) > 10^11 for n >= 13), which is the record sequence behind
  the page's unboundedness discussion.
- **#943** (1_A*1_A(n) for A = powerful numbers): [A085252](https://oeis.org/A085252) "Number
  of ways to write n as sum of two powerful numbers" (unordered; the convolution in the problem
  counts ordered pairs), with [A085253](https://oeis.org/A085253) (no representation) and
  [A085255](https://oeis.org/A085255) (at least two representations).

**Link added, `possible` retained (further sequences plausible):**

- **#1161** (f_k(n) = number of elements of S_n of order k): [A057731](https://oeis.org/A057731)
  is exactly the triangle T(n,k) = f_k(n) (rows n >= 1, k up to Landau's g(n)). The "which k
  maximises f_k(n)" sequence from Beker's result is not in the OEIS, hence `possible` kept.

- **#939** (coprime r-powerful sums): [A297867](https://oeis.org/A297867) "3-powerful numbers
  that can be written as the sum of two coprime 3-powerful numbers" is the object of the third
  question (Nitaj/Cohn/Walsh); [A036966](https://oeis.org/A036966) is the base set of 3-full
  numbers. The r >= 4 examples (Cambie, r = 5, 7, 8) are not sequenced.
- **#1140** (n with n - 2x^2 prime for all 2x^2 < n): [A240842](https://oeis.org/A240842)
  "Numbers n such that n - 2k^2 is a prime for all k > 0 with k^2 < n/2": 1, 2, 4, 5, 7, 13, 15,
  21, 25, 31, 49, 55, 61, 91, 181, 199, no others below 10^17 (Greathouse). The problem's
  quantifier includes x = 0, i.e. n prime; A240842 restricted to primes is 2, 5, 7, 13, 31, 61,
  181, 199, exactly the page's list (Epure–Gica). I recomputed A240842 for n < 20000 and it
  agrees. A primes-only version does not exist in the OEIS.
- **#308** (smallest integer not a sum of distinct unit fractions with denominators <= N):
  [A101877](https://oeis.org/A101877) is the inverse function — the least max denominator k
  such that some set of distinct unit fractions with max k sums to n: 1, 6, 24, 65, 184, 469,
  1243, 3231. I recomputed the problem's f(N) for N <= 24 (f = 2 for N <= 5, 3 for 6 <= N <= 23,
  4 at N = 24), matching A101877(1..3). Croot's theorem on the page is about this threshold.
- **#634** (n such that some triangle can be cut into n congruent triangles):
  [A005792](https://oeis.org/A005792) — numbers of the form k^2, k^2 + m^2, 3k^2 — is the
  Golomb/Snover theorem for the case where the n congruent pieces are also similar to the
  original triangle, and the entry's comments (Bonfioli, Aug 2026) discuss the congruent-only
  case of this problem explicitly (28, 44, 77, 99 realizable but not in the sequence), with
  links to Beeson's triangle-tiling papers and a 2026 note on primes = 3 (mod 4). The
  congruent-only set itself (Soifer's 2n^2, 6n^2 families included) is not an OEIS sequence,
  hence `possible` kept. If the maintainers consider the similar-copies sequence too far from
  the problem, drop this one edit; the other six stand alone.

**Validation:** `scripts/validate.py --base <base problems.yaml>` on the edited file reports
exactly the same six pre-existing schema errors as the untouched base at eea72a4c (entries with
`formal_status.state: "formalized"`, which the current schema enum does not accept) and nothing
new; the YAML parses (1,217 entries) and only the seven `oeis` lines differ.

**AI disclosure** (per the CONTRIBUTING policy): the candidate screening, OEIS lookups and the
small term recomputations were done with Claude (Anthropic) assistance; every A-number and
definition above was checked against the live OEIS entry and the problem page by me before
opening this PR. No new OEIS sequence is submitted here; this PR only links existing entries.

**Note:** an eighth candidate, #694, gained its OEIS links upstream between my Sep 3 clone and this PR (A002181, A006511, A049283, A057635), so it is not included here. Base: upstream main at 7688a2b0 (2026-09-05).