### PR TITLE
1171 -> `not disprovable`

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -19094,8 +19094,8 @@
 - number: "1171"
   prize: "no"
   informal_status:
-    state: "open"
-    last_update: "2026-01-23"
+    state: "not disprovable"
+    last_update: "2026-09-05"
   formal_status:
     state: "unformalized"
   status:


### PR DESCRIPTION
The site already records that Baumgartner proved ω₁ω → (ω₁ω, 3)² under Martin's axiom. Problem 1171 asks for slightly more (any finite number of colors, and ω₁² in place of ω₁ω), but both follow from Baumgartner, so under Martin's axiom the problem's statement holds.

Since Martin's axiom is consistent relative to ZFC, the statement is true in some model of ZFC. So it cannot be disproved in ZFC, which is the definition of `not disprovable`.