### PR TITLE
Link problem 84 to OEIS A399654

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -1375,7 +1375,7 @@
   status:
     state: "open"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A399654"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Replaces the `possible` OEIS marker for Erdős Problem 84 with the newly published sequence [A399654](https://oeis.org/A399654).

Closes #290

Validation:
- `.venv/bin/python scripts/validate.py`

AI assistance: The one-line repository update and PR preparation were performed with AI assistance.