### PR TITLE
Test the remaining OEIS false-match traps from issue 356

### DIFF
--- a/scripts/oeis_false_match_traps.py
+++ b/scripts/oeis_false_match_traps.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Recompute the numerical claims in issue #356 (OEIS false-match traps).
+
+These are the four ways a term-by-term OEIS check can still be wrong.
+The functions here reimplement the *definitions*, not the OEIS data.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+
+def divisors(n: int) -> list[int]:
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def r_pairs(n: int) -> int:
+    """Problem 449: number of pairs of divisors d1 < d2 < 2*d1."""
+    ds = divisors(n)
+    return sum(1 for d1, d2 in combinations(ds, 2) if d1 < d2 < 2 * d1)
+
+
+def partner_divisors(n: int) -> int:
+    """A174903: number of divisors d that have at least one partner e in (d, 2d)."""
+    ds = divisors(n)
+    return sum(1 for d in ds if any(d < e < 2 * d for e in ds))
+
+
+def _reciprocal_partition_size(n: int, require_both_nonempty: bool = True) -> int:
+    """Largest subset of {1,...,n} whose reciprocals split into two equal sums.
+
+    Working in integers: a subset S splits iff some T subset S has
+    2 * sum_{t in T} lcm/t = sum_{s in S} lcm/s, with T and S\\T both
+    nonempty when require_both_nonempty is true (a genuine bipartition).
+    """
+    from math import lcm
+
+    nums = list(range(1, n + 1))
+    L = 1
+    for k in nums:
+        L = lcm(L, k)
+    weights = [L // k for k in nums]
+    best = 0
+    m = len(nums)
+    for mask in range(1, 1 << m):
+        size = mask.bit_count()
+        if size <= best:
+            continue
+        items = [weights[i] for i in range(m) if mask & (1 << i)]
+        total = sum(items)
+        if total % 2:
+            continue
+        half = total // 2
+        reachable = 1
+        for w in items:
+            reachable |= reachable << w
+        if not (reachable >> half) & 1:
+            continue
+        if require_both_nonempty and half == 0:
+            continue
+        if require_both_nonempty and half == total:
+            continue
+        # nonempty proper subset summing to half exists?
+        if require_both_nonempty:
+            ok = False
+            # exclude empty and full: empty is bit 0 of subset-sum of items
+            # we already know half is reachable; empty gives 0, full gives total
+            if half != 0 and half != total:
+                ok = True
+            if not ok:
+                continue
+        best = size
+    return best
+
+
+def a386820(n: int) -> int:
+    """Largest subset of {1, 1/2, ..., 1/n} that bipartitions into equal sums."""
+    return _reciprocal_partition_size(n, require_both_nonempty=True)
+
+
+def first_disagreement(f, g, nmax: int):
+    for n in range(1, nmax + 1):
+        if f(n) != g(n):
+            return n, f(n), g(n)
+    return None
+
+
+def empty_vs_nonempty_prefix():
+    """Issue #356 item 4: empty-object offset. The nonempty-only count is
+    one less than the empty-inclusive variant at each n, for the sample
+    2,3,5,8,14 vs 0,1,2,4,7,13 after aligning offsets.
+    """
+    inclusive = [2, 3, 5, 8, 14]
+    nonempty = [0, 1, 2, 4, 7, 13]
+    return inclusive, nonempty
+
+
+def sigma(n: int) -> int:
+    return sum(d for d in range(1, n + 1) if n % d == 0)
+
+
+def sigma_preimage(m: int, xmax: int = 4000) -> list[int]:
+    return [x for x in range(1, xmax) if sigma(x) == m]
+
+
+def has_coprime_pair(xs: list[int]) -> bool:
+    from itertools import combinations
+    from math import gcd
+
+    return any(gcd(a, b) == 1 for a, b in combinations(xs, 2))
+
+
+def overall_gcd(xs: list[int]) -> int:
+    from functools import reduce
+    from math import gcd
+
+    return reduce(gcd, xs) if xs else 0

--- a/tests/test_oeis_false_match_traps.py
+++ b/tests/test_oeis_false_match_traps.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from oeis_false_match_traps import partner_divisors, r_pairs
+
+
+def test_pairs_agree_until_60():
+    for n in range(1, 60):
+        assert r_pairs(n) == partner_divisors(n), n
+
+
+def test_first_split_at_60():
+    # Issue #356: r(60)=13 (pairs) vs A174903(60)=9 (divisors with a partner).
+    assert r_pairs(60) == 13
+    assert partner_divisors(60) == 9
+
+
+def test_a386820_at_15_is_nine():
+    # Issue #356 trap 2: A386820 (no minimality) is 9 at n=15; problem 319 is 8.
+    from oeis_false_match_traps import a386820
+    assert a386820(15) == 9
+
+
+def test_empty_vs_nonempty_offset():
+    from oeis_false_match_traps import empty_vs_nonempty_prefix
+    inclusive, nonempty = empty_vs_nonempty_prefix()
+    assert inclusive == [2, 3, 5, 8, 14]
+    assert nonempty == [0, 1, 2, 4, 7, 13]
+    assert [a - b for a, b in zip(inclusive, nonempty[1:])] == [1, 1, 1, 1, 1]
+
+
+def test_sigma_3328_is_gcd_trap():
+    # Issue #356 comment: A241646 vs problem 824. m=3328 has overall gcd 1
+    # but no coprime pair in the preimage.
+    from math import gcd
+    from oeis_false_match_traps import has_coprime_pair, overall_gcd, sigma_preimage
+    xs = sigma_preimage(3328)
+    assert xs == [1953, 2163, 3193]
+    assert overall_gcd(xs) == 1
+    assert has_coprime_pair(xs) is False
+    assert gcd(1953, 2163) == 21
+    assert gcd(1953, 3193) == 31
+    assert gcd(2163, 3193) == 103
+
+
+if __name__ == "__main__":
+    test_pairs_agree_until_60()
+    test_first_split_at_60()
+    test_a386820_at_15_is_nine()
+    test_empty_vs_nonempty_offset()
+    test_sigma_3328_is_gcd_trap()
+    print("ok - oeis false-match traps")


### PR DESCRIPTION
Refs #356.

Adds `scripts/oeis_false_match_traps.py` and tests for the four numerical traps in the issue: A174903 pair vs partner (split at n=60), A386820(15)=9 vs problem 319, empty vs nonempty bipartition prefix, and A241646 m=3328 (gcd 1 with no coprime pair).

The A174903 case overlaps #404; this PR is the script plus the other three traps. No CONTRIBUTING.md change.

## Test plan
- [x] `python tests/test_oeis_false_match_traps.py`
