### PR TITLE
Link problem 1105 to OEIS A399683 and A399687

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -18034,7 +18034,7 @@
   formalized:
     state: "yes"
     last_update: "2026-01-18"
-  oeis: ["possible"]
+  oeis: ["A399683", "A399687"]
   tags: ["graph theory", "ramsey theory"]
 
 - number: "1106"


### PR DESCRIPTION
Updates Problem 1105's OEIS field from possible to A399683 (paths) and A399687 (cycles). Validation: .venv/bin/python scripts/validate.py.