### PR TITLE
Compute v(k) for strictly increasing Egyptian decompositions

### DIFF
--- a/scripts/vk_unit_fractions.py
+++ b/scripts/vk_unit_fractions.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""v(k) for Erdős problem 293 (issue #403).
+
+v(k) is the smallest integer m > 1 that does not occur as a denominator in any
+strictly increasing k-term unit-fraction decomposition of 1.
+"""
+from __future__ import annotations
+
+from math import gcd
+
+
+def decompositions(k: int, ncap: int) -> list[tuple[int, ...]]:
+    """All 1 = 1/n_1 + … + 1/n_k with 1 ≤ n_1 < … < n_k ≤ ncap."""
+    out: list[tuple[int, ...]] = []
+
+    def rec(k_left: int, numer: int, denom: int, start: int, acc: list[int]) -> None:
+        if k_left == 1:
+            if numer == 1 and denom >= start and denom <= ncap:
+                out.append(tuple(acc + [denom]))
+            return
+        lo = max(start, (denom + numer - 1) // numer)
+        hi = min(ncap, k_left * denom // numer)
+        for n in range(lo, hi + 1):
+            nn = numer * n - denom
+            nd = denom * n
+            if nn <= 0:
+                continue
+            g = gcd(nn, nd)
+            rec(k_left - 1, nn // g, nd // g, n + 1, acc + [n])
+
+    rec(k, 1, 1, 1, [])
+    return out
+
+
+def appearing_denominators(k: int, ncap: int) -> set[int]:
+    dens: set[int] = set()
+    for t in decompositions(k, ncap):
+        dens.update(t)
+    return dens
+
+
+def v(k: int, ncap: int | None = None) -> int:
+    """Smallest m > 1 absent from all k-term decompositions with n_k ≤ ncap."""
+    if k < 1:
+        raise ValueError("k must be positive")
+    if ncap is None:
+        ncap = {1: 2, 2: 2, 3: 12, 4: 80, 5: 200}[k]
+    dens = appearing_denominators(k, ncap)
+    m = 2
+    while m in dens:
+        m += 1
+        if m > ncap + 1:
+            raise RuntimeError(f"v({k}) not found below {ncap}")
+    return m

--- a/scripts/vk_unit_fractions.py
+++ b/scripts/vk_unit_fractions.py
@@ -43,6 +43,8 @@ def v(k: int, ncap: int | None = None) -> int:
     """Smallest m > 1 absent from all k-term decompositions with n_k ≤ ncap."""
     if k < 1:
         raise ValueError("k must be positive")
+    if ncap is not None and ncap < 1:
+        raise ValueError("ncap must be positive")
     if ncap is None:
         ncap = {1: 2, 2: 2, 3: 12, 4: 80, 5: 200}[k]
     dens = appearing_denominators(k, ncap)

--- a/tests/test_vk_unit_fractions.py
+++ b/tests/test_vk_unit_fractions.py
@@ -48,4 +48,5 @@ if __name__ == "__main__":
     test_k2_no_strictly_increasing_split()
     test_k3_uses_2_3_6_and_misses_4()
     test_k4_matches_issue_403()
+    test_rejects_nonpositive_k()
     print("ok - v(k)")

--- a/tests/test_vk_unit_fractions.py
+++ b/tests/test_vk_unit_fractions.py
@@ -35,6 +35,14 @@ def test_k4_matches_issue_403():
     assert 11 not in dens
 
 
+def test_rejects_nonpositive_k():
+    try:
+        v(0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
 if __name__ == "__main__":
     test_k1_no_decomposition_above_one()
     test_k2_no_strictly_increasing_split()

--- a/tests/test_vk_unit_fractions.py
+++ b/tests/test_vk_unit_fractions.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from vk_unit_fractions import appearing_denominators, decompositions, v
+
+
+def test_k1_no_decomposition_above_one():
+    # Only 1 = 1/1, so every m > 1 is absent.
+    assert decompositions(1, 5) == [(1,)]
+    assert v(1) == 2
+
+
+def test_k2_no_strictly_increasing_split():
+    assert decompositions(2, 10) == []
+    assert v(2) == 2
+
+
+def test_k3_uses_2_3_6_and_misses_4():
+    triples = decompositions(3, 12)
+    assert (2, 3, 6) in triples
+    dens = appearing_denominators(3, 12)
+    assert 2 in dens and 3 in dens and 6 in dens
+    assert 4 not in dens
+    assert v(3) == 4
+
+
+def test_k4_matches_issue_403():
+    # ncap must be large enough that 7,8,9,10 appear (else v would look like 7).
+    assert v(4, ncap=80) == 11
+    dens = appearing_denominators(4, 80)
+    for m in range(2, 11):
+        assert m in dens, m
+    assert 11 not in dens
+
+
+if __name__ == "__main__":
+    test_k1_no_decomposition_above_one()
+    test_k2_no_strictly_increasing_split()
+    test_k3_uses_2_3_6_and_misses_4()
+    test_k4_matches_issue_403()
+    print("ok - v(k)")


### PR DESCRIPTION
## Summary
- scripts/vk_unit_fractions.py enumerates strictly increasing k-term unit-fraction splits of 1
- tests pin v(1)=2, v(2)=2, v(3)=4, and v(4)=11 once 7 through 10 have appeared (issue 403)

## Test plan
- `python3 tests/test_vk_unit_fractions.py`
