### PR TITLE
Link problem 896 to OEIS A399711

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -14634,7 +14634,7 @@
   status:
     state: "solved"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A399711"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Replaces the `possible` OEIS marker for Erdős Problem 896 with the newly published sequence [A399711](https://oeis.org/A399711).

A399711 records the maximum in Problem 896 and links back to the problem page.

Validation:

- `.venv/bin/python scripts/validate.py`

AI assistance: The one-line repository update and PR preparation were performed with AI assistance.