### PR TITLE
Link problem 793 to OEIS A399779

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -12967,7 +12967,7 @@
   status:
     state: "proved (Lean)"
     last_update: "2025-08-31"
-  oeis: ["possible"]
+  oeis: ["A399779"]
   formalized:
     state: "no"
     last_update: "2025-08-31"


### PR DESCRIPTION
Replaces the `possible` OEIS marker for Erdős Problem 793 with the newly published sequence [A399779](https://oeis.org/A399779).

Validation:

- `.venv/bin/python scripts/validate.py`

AI assistance: The one-line repository update and PR preparation were performed with AI assistance.