### PR TITLE
Add problems 1218–1221; mark 1221 as ambiguous

### DIFF
--- a/data/problems.yaml
+++ b/data/problems.yaml
@@ -19846,3 +19846,68 @@
     last_update: "2026-04-04"
   oeis: ["N/A"]
   tags: ["number theory", "divisors", "primitive sets"]
+
+- number: "1218"
+  prize: "no"
+  informal_status:
+    state: "open"
+    last_update: "2026-09-12"
+  formal_status:
+    state: "unformalized"
+  status:
+    state: "open"
+    last_update: "2026-09-12"
+  formalized:
+    state: "no"
+    last_update: "2026-09-12"
+  oeis: ["N/A"]
+  tags: ["ramsey theory", "set theory"]
+
+- number: "1219"
+  prize: "no"
+  informal_status:
+    state: "proved"
+    last_update: "2026-09-12"
+  formal_status:
+    state: "unformalized"
+  status:
+    state: "proved"
+    last_update: "2026-09-12"
+  formalized:
+    state: "no"
+    last_update: "2026-09-12"
+  oeis: ["N/A"]
+  tags: ["ramsey theory", "set theory"]
+
+- number: "1220"
+  prize: "no"
+  informal_status:
+    state: "open"
+    last_update: "2026-09-12"
+  formal_status:
+    state: "unformalized"
+  status:
+    state: "open"
+    last_update: "2026-09-12"
+  formalized:
+    state: "no"
+    last_update: "2026-09-12"
+  oeis: ["N/A"]
+  tags: ["ramsey theory", "set theory"]
+
+- number: "1221"
+  prize: "no"
+  informal_status:
+    state: "open"
+    last_update: "2026-09-12"
+  formal_status:
+    state: "unformalized"
+  status:
+    state: "open"
+    last_update: "2026-09-12"
+  formalized:
+    state: "no"
+    last_update: "2026-09-12"
+  oeis: ["N/A"]
+  comments: "ambiguous statement"
+  tags: ["analysis", "distribution"]


### PR DESCRIPTION
## Summary
- Sync newly published site problems 1218–1221 into `data/problems.yaml`
- Mark 1221 with `comments: ambiguous statement` for the missing factor-of-r normalisation discussed in #414

## Test plan
- [x] `python scripts/validate.py`
- [x] `python scripts/derive_status.py` (already up to date)

Fixes #414