### PR TITLE
Add r(n) calculator for nearby divisor pairs (problem 449)

### DIFF
--- a/scripts/nearby_divisor_pairs.py
+++ b/scripts/nearby_divisor_pairs.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""r(n) for Erdős problem 449 (reported in issue #354).
+
+r(n) = #{(d1, d2) : d1 | n, d2 | n, d1 < d2 < 2 d1}.
+"""
+from __future__ import annotations
+
+import math
+
+
+def divisors(n: int) -> list[int]:
+    out = []
+    for i in range(1, int(math.isqrt(n)) + 1):
+        if n % i == 0:
+            out.append(i)
+            if i * i != n:
+                out.append(n // i)
+    return sorted(out)
+
+
+def r(n: int) -> int:
+    ds = divisors(n)
+    count = 0
+    for i, d1 in enumerate(ds):
+        for d2 in ds[i + 1 :]:
+            if d2 < 2 * d1:
+                count += 1
+            else:
+                break
+    return count
+
+
+# Issue #354 table for n = 1..90
+ISSUE_PREFIX = [
+    0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 3, 0, 0, 1, 0, 0, 2, 0, 1, 0, 0, 0, 5, 0, 0, 0, 1, 0, 5,
+    0, 0, 0, 0, 1, 6, 0, 0, 0, 3, 0, 3, 0, 0, 3, 0, 0, 7, 0, 0, 0, 0, 0, 3, 0, 3, 0, 0, 0, 13,
+    0, 0, 1, 0, 0, 3, 0, 0, 0, 3, 0, 11, 0, 0, 2, 0, 1, 2, 0, 5, 0, 0, 0, 11, 0, 0, 0, 1, 0, 13,
+]
+
+
+if __name__ == "__main__":
+    import sys
+    maxn = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+    print(",".join(str(r(n)) for n in range(1, maxn + 1)))

--- a/tests/test_nearby_divisor_pairs.py
+++ b/tests/test_nearby_divisor_pairs.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from nearby_divisor_pairs import ISSUE_PREFIX, r
+
+def test_matches_issue_354():
+    for n, want in enumerate(ISSUE_PREFIX, 1):
+        assert r(n) == want, (n, r(n), want)
+
+def test_a174903_divergence_at_60():
+    # A174903 counts partnered divisors, not pairs; first split at n=60.
+    assert r(60) == 13
+
+if __name__ == "__main__":
+    test_matches_issue_354()
+    test_a174903_divergence_at_60()
+    print("ok - nearby divisor pairs")


### PR DESCRIPTION
## Summary
- Implements r(n) for nearby divisor pairs
- Reproduces the issue #354 table; notes A174903 near-miss at n=60

## Test plan
- [x] `python tests/test_nearby_divisor_pairs.py`

Refs #354