### PR TITLE
Keep invalid URL sorting and page sizes from breaking the table

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -19,10 +19,7 @@ function getPageSizeFromUI() {
 
     // Keep the last valid value while the user is typing.
     const value = input.value.trim();
-    if (!/^[1-9]\d*$/.test(value)) return pageSize;
-
-    // Regex guarantees a positive integer.
-    return Number(value);
+    return parsePositiveInteger(value, pageSize);
 }
 
 function setPageSizeInUI(size) {

--- a/docs/url-state.js
+++ b/docs/url-state.js
@@ -83,6 +83,12 @@ function saveStateToURL(state) {
     window.history.replaceState(null, '', newURL);
 }
 
+/** Parse a positive, exactly representable integer, retaining the fallback otherwise. */
+function parsePositiveInteger(value, fallback) {
+    const number = Number(value);
+    return /^[1-9]\d*$/.test(value) && Number.isSafeInteger(number) ? number : fallback;
+}
+
 /**
  * Load state from URL query parameters
  * @returns {Object} State object with default values for missing parameters
@@ -91,10 +97,10 @@ function loadStateFromURL() {
     const params = new URLSearchParams(window.location.search);
 
     const pageRaw = params.get('page') || '1';
-    const page = /^[1-9]\d*$/.test(pageRaw) ? Number(pageRaw) : 1;
+    const page = parsePositiveInteger(pageRaw, 1);
 
     const pageSizeRaw = params.get('pageSize') || '100';
-    const pageSize = /^[1-9]\d*$/.test(pageSizeRaw) ? Number(pageSizeRaw) : 100;
+    const pageSize = parsePositiveInteger(pageSizeRaw, 100);
 
     // Backwards compatibility: links created before the status was split into
     // an informal and a formal part used a single combined value, such as
@@ -109,9 +115,12 @@ function loadStateFromURL() {
         }
     }
 
+    const sortableColumns = ['number', 'prize', 'status', 'formal', 'formalized', 'ai_attempts', 'oeis', 'tags', 'comments'];
+    const sortColumn = params.get('sort');
+
     return {
-        sortColumn: params.get('sort') || 'number',
-        sortDirection: params.get('dir') || 'asc',
+        sortColumn: sortableColumns.includes(sortColumn) ? sortColumn : 'number',
+        sortDirection: params.get('dir') === 'desc' ? 'desc' : 'asc',
         search: params.get('q') || '',
         statusFilter,
         formalFilter,

--- a/tests/test-url-state.cjs
+++ b/tests/test-url-state.cjs
@@ -1,0 +1,60 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+
+function app(search = '') {
+    const input = { value: '100' };
+    const document = {
+        readyState: 'loading',
+        addEventListener() {},
+        getElementById(id) { return id === 'page-size' ? input : null; }
+    };
+    const context = vm.createContext({ URLSearchParams, window: { location: { search } }, document, console });
+    for (const file of ['utils.js', 'url-state.js', 'app.js']) {
+        vm.runInContext(fs.readFileSync(path.join(__dirname, '../docs', file), 'utf8'), context);
+    }
+    return { context, input };
+}
+
+test('invalid sort settings fall back to a supported column and direction', () => {
+    for (const column of ['"', 'missing', 'number"][' ]) {
+        const { context } = app('?sort=' + encodeURIComponent(column) + '&dir=sideways');
+        const state = context.loadStateFromURL();
+        assert.equal(state.sortColumn, 'number');
+        assert.equal(state.sortDirection, 'asc');
+    }
+});
+
+test('valid sorting and legacy combined status links retain their meaning', () => {
+    const { context } = app('?sort=prize&dir=desc&status=proved%20(Lean)&page=2&pageSize=50');
+    const state = context.loadStateFromURL();
+    assert.equal(state.sortColumn, 'prize');
+    assert.equal(state.sortDirection, 'desc');
+    assert.equal(state.statusFilter, 'proved');
+    assert.equal(state.formalFilter, 'Lean');
+    assert.equal(state.page, 2);
+    assert.equal(state.pageSize, 50);
+});
+
+for (const value of ['0', '-1', '1.5', '1e3', '9007199254740993', '9'.repeat(400)]) {
+    test('URL pagination rejects invalid or unsafe integers: ' + value.slice(0, 20), () => {
+        const { context } = app('?page=' + value + '&pageSize=' + value);
+        const state = context.loadStateFromURL();
+        assert.equal(state.page, 1);
+        assert.equal(state.pageSize, 100);
+    });
+    test('page size input keeps the last valid value: ' + value.slice(0, 20), () => {
+        const { context, input } = app();
+        input.value = value;
+        assert.equal(context.getPageSizeFromUI(), 100);
+    });
+}
+
+test('large safe page sizes remain supported', () => {
+    const { context, input } = app('?pageSize=10000');
+    assert.equal(context.loadStateFromURL().pageSize, 10000);
+    input.value = '10000';
+    assert.equal(context.getPageSizeFromUI(), 10000);
+});


### PR DESCRIPTION
Malformed shared-link settings can prevent the interactive table from loading. A quote in `sort` reaches a CSS selector and throws; a digit-only page size larger than JavaScript's numeric range becomes `Infinity`, producing an empty page through `0 * Infinity`.

Validate sort columns and directions when restoring URL state. Parse pagination as positive safe integers, using the same parser for the page-size input so invalid input keeps the last valid size. Valid sorting, pagination, and legacy `status=proved (Lean)` links are preserved.

Validation: `node --test tests/test-url-state.cjs` passes all 15 tests (five fail before the change). A real browser loaded all 1,217 problems from a URL containing an invalid sort value and a 400-digit page size, showing rows 1–100, page 1/13, and the default ascending sort. `git diff --check` passes.
